### PR TITLE
Removed uptime dependency, added shebang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ commands_topic.txt
 .vscode/launch.json
 .DS_Store
 Configurator/configurations.json
+bin
+lib
+lib64
+pyvenv.cfg

--- a/Entity/Deployments/BootTime/BootTime.py
+++ b/Entity/Deployments/BootTime/BootTime.py
@@ -1,14 +1,17 @@
-import uptime
+import datetime
+import psutil
 from Entity.Entity import Entity
-from Entity.EntityData import EntitySensor 
+from Entity.EntityData import EntitySensor
 
 KEY_BOOT_TIME = 'boot_time'
+
 
 class BootTime(Entity):
     NAME = "BootTime"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self,KEY_BOOT_TIME))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_BOOT_TIME))
 
     def Update(self):
-        self.SetEntitySensorValue(KEY_BOOT_TIME, str(uptime.boottime().strftime("%Y-%m-%d %H:%M:%S")))
+        self.SetEntitySensorValue(KEY_BOOT_TIME,
+                                  str(datetime.datetime.fromtimestamp(psutil.boot_time())))

--- a/Entity/Deployments/Uptime/Uptime.py
+++ b/Entity/Deployments/Uptime/Uptime.py
@@ -1,9 +1,11 @@
-import uptime
+import psutil
+import time
 from Entity.Entity import Entity
 from Entity.EntityData import EntitySensor
-from Entity.ValueFormatter import ValueFormatter 
+from Entity.ValueFormatter import ValueFormatter
 
 KEY = 'uptime'
+
 
 class Uptime(Entity):
     NAME = "UpTime"
@@ -12,4 +14,5 @@ class Uptime(Entity):
         self.RegisterEntitySensor(EntitySensor(self, KEY))
 
     def Update(self):
-        self.SetEntitySensorValue(KEY, uptime.uptime(), ValueFormatter.Options(ValueFormatter.TYPE_TIME, 0, "m"))
+        self.SetEntitySensorValue(KEY, time.time() - psutil.boot_time(),
+                                  ValueFormatter.Options(ValueFormatter.TYPE_TIME, 0, "m"))

--- a/Entity/ValueFormatter.py
+++ b/Entity/ValueFormatter.py
@@ -96,6 +96,9 @@ class ValueFormatter():
         
         if asked_size and asked_size in BYTE_SIZES:
             powOf1024 = BYTE_SIZES.index(asked_size)
+        # If value == 0 math.log failes, so simply send 0:
+        elif float(value) == 0:
+            powOf1024 = 0
         else:
             powOf1024 = math.floor(math.log(value, 1024))
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from MyApp.App import App
 from Configurator.Configurator import Configurator
 from Configurator.ConfiguratorLoader import ConfiguratorLoader

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,5 +1,4 @@
 paho-mqtt
 psutil
-uptime
 notify2
 PyYAML

--- a/requirements_macos.txt
+++ b/requirements_macos.txt
@@ -1,5 +1,4 @@
 paho-mqtt
 psutil
-uptime
 PyYAML
 PyObjC

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -1,5 +1,4 @@
 paho-mqtt
 psutil
-uptime
 win10toast
 PyYAML


### PR DESCRIPTION
Hello there!

I just found that you started this new project.

I had some contributions on PyMonitorMQTT, I wanted to create a PR, but forgot it. Check out my changes: https://github.com/richibrics/PyMonitorMQTT/compare/master...infeeeee:PyMonitorMQTT:master

I mostly use linux, so I can help on that side.

In this PR I removed `uptime` as a dependency, because it's not available as a standalone package on ArchLinux. All of its used functionality is available with `psutil` and built-in python commands.

I like to use distribution's python packages instead of pip. That way python packages update with the system, and you can avoid  dependency hell more easily.

With the shebang it's possible to call the file directly. So now you can just simply start the script this way on mac and linux:

```shell
./main.py
```

You don't need to call `python` before that.

---

Some constructive criticism: 

I didn't like the new config workflow. Modifying a yaml file was much more straightforward. It would be nice to include an example configuration, so experienced users can set everything up more quickly, without the questionnaire.

Also why do you store the new configuration in json? Will you replace it with yaml? PyYAML is not used anywhere.

Thanks for this nice project!