### PR TITLE
Notify title and message in a payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__
 Logger/Logs
 nogit.*
 commands_topic.txt
-.vscode/launch.json
+.vscode
 .DS_Store
-Configurator/configurations.json
+Configurator/configurations.json*
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,4 @@ commands_topic.txt
 .vscode/launch.json
 .DS_Store
 Configurator/configurations.json
-bin
-lib
-lib64
-pyvenv.cfg
-include/
+.venv

--- a/Entity/Deployments/Notify/Notify.py
+++ b/Entity/Deployments/Notify/Notify.py
@@ -90,7 +90,7 @@ class Notify(Entity):
                 self.notification_message, self.notification_title,)
             os.system(command)
         else:
-            self.Log(self.Logger.LOG_WARNING,"No notify command available for this operating system ("+ str(self.os) +")... Aborting")
+            self.Log(self.LOG_WARNING,"No notify command available for this operating system ("+ str(self.os) +")... Aborting")
 
     @classmethod
     def ConfigurationPreset(self):

--- a/Entity/Deployments/Notify/Notify.py
+++ b/Entity/Deployments/Notify/Notify.py
@@ -23,6 +23,10 @@ except:
 
 KEY = 'notify'
 
+# To send notification data through message payload use these two
+PAYLOAD_KEY_TITLE = "title"
+PAYLOAD_KEY_MESSAGE = "message"
+
 CONFIG_KEY_TITLE = "title"
 CONFIG_KEY_MESSAGE = "message"
 
@@ -69,8 +73,8 @@ class Notify(Entity):
             messageDict = ''
             try:
                 messageDict = eval(message.payload.decode('utf-8'))
-                self.notification_title = messageDict['title']
-                self.notification_message = messageDict['message']
+                self.notification_title = messageDict[PAYLOAD_KEY_TITLE]
+                self.notification_message = messageDict[PAYLOAD_KEY_MESSAGE]
             except:
                 raise Exception(
                     'Incorrect payload and no title and message set in configuration!'

--- a/Entity/Deployments/Notify/Notify.py
+++ b/Entity/Deployments/Notify/Notify.py
@@ -35,8 +35,8 @@ class Notify(Entity):
     
     def Initialize(self):
         try:
-            self.notification_title = self.GetConfigurations()[CONFIG_KEY_TITLE]
-            self.notification_message = self.GetConfigurations()[CONFIG_KEY_MESSAGE]
+            self.config_title = self.GetConfigurations()[CONFIG_KEY_TITLE]
+            self.config_message = self.GetConfigurations()[CONFIG_KEY_MESSAGE]
         except Exception as e:
             raise Exception("Configuration error: " + str(e))
 
@@ -58,15 +58,23 @@ class Notify(Entity):
                     'Notify not available, have you installed \'notify2\' on pip ?')
 
     def Callback(self, message):
-        # TO DO
-        # Convert the payload in a dict
-        messageDict = ''
-        try:
-            messageDict = eval(message.payload.decode('utf-8'))
-        except:
-            pass  # No message or title in the payload
 
         # Priority for configuration content and title. If not set there, will try to find them in the payload
+        if self.config_title and self.config_message:
+            self.notification_title = self.config_title
+            self.notification_message = self.config_message
+        
+        else:
+            # Convert the payload to a dict:
+            messageDict = ''
+            try:
+                messageDict = eval(message.payload.decode('utf-8'))
+                self.notification_title = messageDict['title']
+                self.notification_message = messageDict['message']
+            except:
+                raise Exception(
+                    'Incorrect payload and no title and message set in configuration!'
+                )
 
         # Check only the os (if it's that os, it's supported because if it wasn't supported,
         # an exception would be thrown in post-inits)
@@ -87,6 +95,6 @@ class Notify(Entity):
     @classmethod
     def ConfigurationPreset(self):
         preset = MenuPreset()
-        preset.AddEntry("Notification title", CONFIG_KEY_TITLE, mandatory=True)
-        preset.AddEntry("Notification message", CONFIG_KEY_MESSAGE, mandatory=True)
+        preset.AddEntry("Notification title (Leave empty if you want to define it in the payload)", CONFIG_KEY_TITLE)
+        preset.AddEntry("Notification message (Leave empty if you want to define it in the payload)", CONFIG_KEY_MESSAGE)
         return preset

--- a/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
+++ b/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
@@ -96,7 +96,7 @@ class HomeAssistantWarehouse(Warehouse):
                 if entityData in entity.GetEntitySensors(): # it's an EntitySensorData
                     data_type = "sensor"
                 else: # it's a EntityCommandData
-                    data_type = "switch"
+                    data_type = "button"
 
                 # add custom info to the entity data, reading it from external file and accessing the information using the entity data name
                 payload = self.AddEntityDataCustomConfigurations(payload['name'], payload)

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,4 +1,5 @@
 paho-mqtt
 psutil
+dbus-python
 notify2
 PyYAML


### PR DESCRIPTION
Hi!

I saw you already started working on this, I just finished it :)

If there is anything set up as title or message in `configuration.json` than it takes precedence, as you commented. The user have to just hit enter on the configuration flow to enable message as payload.

I also changed how commands show up in HomeAssistant, I think a `button` data type is better for the commands, as they don't have 2 states as expected from a switch.