### PR TITLE
Support for states on EntityCommands, Monitor entity as a switch with state topic

### DIFF
--- a/IoTuring/Entity/Deployments/Monitor/Monitor.py
+++ b/IoTuring/Entity/Deployments/Monitor/Monitor.py
@@ -1,6 +1,7 @@
 import subprocess
 import ctypes
 import os
+import re
 
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntityCommand, EntitySensor
@@ -48,6 +49,7 @@ class Monitor(Entity):
             elif self.os == consts.OS_FIXED_VALUE_LINUX:
                 command = 'xset dpms force on'
                 subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+                self.SetEntityCommandState(KEY, STATE_ON)
 
         elif payloadString == STATE_OFF:
             if self.os == consts.OS_FIXED_VALUE_WINDOWS:
@@ -55,6 +57,7 @@ class Monitor(Entity):
             elif self.os == consts.OS_FIXED_VALUE_LINUX:
                 command = 'xset dpms force off'
                 subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+                self.SetEntityCommandState(KEY, STATE_OFF)
         else:
             raise Exception('Incorrect payload!')
 

--- a/IoTuring/Entity/Deployments/Monitor/Monitor.py
+++ b/IoTuring/Entity/Deployments/Monitor/Monitor.py
@@ -1,17 +1,18 @@
 import subprocess
 import ctypes
-import os as sys_os
+import os
+
 from IoTuring.Entity.Entity import Entity
-from ctypes import *
+from IoTuring.Entity.EntityData import EntityCommand, EntitySensor
+from IoTuring.Entity import consts
+from IoTuring.Logger.consts import STATE_OFF, STATE_ON
 
-from IoTuring.Entity.EntityData import EntityCommand
 
-KEY_TURN_ALL_OFF = 'turn_all_off'
-KEY_TURN_ALL_ON = 'turn_all_on'
-
+KEY='monitor'
 
 class Monitor(Entity):
     NAME = "Monitor"
+    DEPENDENCIES = ["Os"]
 
     def Initialize(self):
         pass
@@ -19,26 +20,50 @@ class Monitor(Entity):
     def PostInitialize(self):
         self.os = self.GetDependentEntitySensorValue('Os', "operating_system")
 
-        if self.os == 'Windows' or (self.os == 'Linux' and sys_os.environ.get('DISPLAY')):
-            self.RegisterEntityCommand(EntityCommand(
-                self, KEY_TURN_ALL_OFF, self.CallbackTurnAllOff))
-            self.RegisterEntityCommand(EntityCommand(
-                self, KEY_TURN_ALL_ON, self.CallbackTurnAllOn))
+        if self.os == consts.OS_FIXED_VALUE_LINUX:
+            # Check if xset is working:
+            p = subprocess.run(['xset','dpms'], capture_output=True, shell=False)
+            if p.stderr:
+                raise Exception(f"Xset dpms error: {p.stderr.decode()}")
+            elif not os.getenv('DISPLAY'):
+                raise Exception('No $DISPLAY environment variable!')
+            else:
+                supports_linux = True        
 
-    def CallbackTurnAllOff(self, message):
-        if self.os == 'Windows':
-            ctypes.windll.user32.SendMessageA(0xFFFF, 0x0112, 0xF170, 2)
-        elif self.os == 'Linux':
-            # Check if X11 or something else
-            if sys_os.environ.get('DISPLAY'):
-                command = 'xset dpms force off'
-                subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+        if self.os == consts.OS_FIXED_VALUE_WINDOWS:
+            self.RegisterEntityCommand(EntityCommand(
+                self, KEY, self.Callback))
+        elif supports_linux:
+            # Support for sending state on linux
+            self.RegisterEntityCommand(EntityCommand(
+                    self, KEY, self.Callback, supportsState=True))
+            
 
-    def CallbackTurnAllOn(self, message):
-        if self.os == 'Windows':
-            ctypes.windll.user32.SendMessageA(0xFFFF, 0x0112, 0xF170, -1)
-        elif self.os == 'Linux':
-            # Check if X11 or something else
-            if sys_os.environ.get('DISPLAY'):
+    def Callback(self, message):
+        payloadString = message.payload.decode('utf-8')
+
+        if payloadString == STATE_ON:
+            if self.os == consts.OS_FIXED_VALUE_WINDOWS:
+                ctypes.windll.user32.SendMessageA(0xFFFF, 0x0112, 0xF170, -1)
+            elif self.os == consts.OS_FIXED_VALUE_LINUX:
                 command = 'xset dpms force on'
                 subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+
+        elif payloadString == STATE_OFF:
+            if self.os == consts.OS_FIXED_VALUE_WINDOWS:
+                ctypes.windll.user32.SendMessageA(0xFFFF, 0x0112, 0xF170, 2)
+            elif self.os == consts.OS_FIXED_VALUE_LINUX:
+                command = 'xset dpms force off'
+                subprocess.Popen(command.split(), stdout=subprocess.PIPE)
+        else:
+            raise Exception('Incorrect payload!')
+
+    def Update(self):
+        if self.os == consts.OS_FIXED_VALUE_LINUX:
+            p = subprocess.run(['xset','q'], capture_output=True, shell=False)          
+            outputString = p.stdout.decode()
+            monitorState = re.findall('Monitor is (.{2,3})', outputString)[0].upper()
+            if monitorState in [STATE_OFF, STATE_ON]:
+                self.SetEntityCommandState(KEY, monitorState)
+            else:
+                raise Exception(f'Incorrect monitor state: {monitorState}')

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -96,6 +96,16 @@ class Entity(LogObject):
 
         self.GetEntitySensorByKey(key).SetValue(value)
 
+    def SetEntityCommandState(self, key, value, value_formatter_options=None) -> None:
+        """ Set the value of an entitycommand state """
+        if value_formatter_options is not None:
+            value = ValueFormatter.GetFormattedValue(
+                value, value_formatter_options)
+
+        value = str(value)
+
+        self.GetEntityCommandByKey(key).SetState(value)
+
     def GetEntitySensorValue(self, key) -> str:
         """ Get value using its entity sensor key if the value is present (else raise an exception) """
         if not self.GetEntitySensorByKey(key).HasValue():
@@ -157,6 +167,12 @@ class Entity(LogObject):
         for sensor in self.entitySensors:
             if sensor.GetKey() == key:
                 return sensor
+        raise UnknownEntityKeyException
+    
+    def GetEntityCommandByKey(self, key) -> EntityCommand:
+        for command in self.entityCommands:
+            if command.GetKey() == key:
+                return command
         raise UnknownEntityKeyException
 
     def GetEntityName(self) -> str:

--- a/IoTuring/Entity/EntityData.py
+++ b/IoTuring/Entity/EntityData.py
@@ -62,9 +62,11 @@ class EntitySensor(EntityData):
 
 class EntityCommand(EntityData):
 
-    def __init__(self, entity, key, callbackFunction):
+    def __init__(self, entity, key, callbackFunction, supportsState = False):
         EntityData.__init__(self, entity, key)
         self.callbackFunction = callbackFunction
+        self.supportsState = supportsState
+        self.state = None
 
     def CallCallback(self, message):
         """ Safely run callback for this command, passing the message (a paho.mqtt.client.MQTTMessage) """
@@ -78,3 +80,19 @@ class EntityCommand(EntityData):
         """ Called only by CallCallback. 
             Run callback for this command, passing the message (a paho.mqtt.client.MQTTMessage) """
         self.callbackFunction(message)
+
+    def DoesSupportState(self):
+        return self.supportsState
+
+    def GetState(self):
+        return self.state
+
+    def SetState(self, state):
+        state = str(state)
+        self.Log(self.LOG_DEBUG, "Set to " + state)
+        self.state = state
+        return self.state
+
+    def HasState(self):
+        """ True if self.state isn't empty """
+        return self.state is not None

--- a/IoTuring/Logger/consts.py
+++ b/IoTuring/Logger/consts.py
@@ -11,6 +11,10 @@ LOG_DEBUG = 4
 LOG_DEVELOPMENT = 5
 
 
+# On/off states as strings:
+STATE_ON = "ON"
+STATE_OFF = "OFF"
+
 # Fill start of string with spaces to jusitfy the message (0: no padding)
 # First for type, second for source
 STRINGS_LENGTH = [8, 30]

--- a/IoTuring/Warehouse/Deployments/ConsoleWarehouse/ConsoleWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/ConsoleWarehouse/ConsoleWarehouse.py
@@ -8,6 +8,11 @@ class ConsoleWarehouse(Warehouse):
     def Loop(self):
         for entity in self.GetEntities():
             for entitySensor in entity.GetEntitySensors():
-                if(entitySensor.HasValue()):
-                    self.Log(Logger.LOG_MESSAGE, entitySensor.GetId() +
-                             ": " + entitySensor.GetValue())
+                if entitySensor.HasValue():
+                    self.Log(Logger.LOG_MESSAGE, 
+                        f"{entitySensor.GetId()}: {entitySensor.GetValue()}")
+            for entityCommand in entity.GetEntityCommands():
+                if entityCommand.HasState():
+                    self.Log(Logger.LOG_MESSAGE, 
+                        f"{entityCommand.GetId()}: {entityCommand.GetState()}")
+                    

--- a/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
@@ -19,7 +19,6 @@ TOPIC_DATA_EXTRA_ATTRIBUTES_SUFFIX = "_extraattributes"
 # That stands for: Entity data type, App name, EntityData Id
 # to send configuration data
 TOPIC_AUTODISCOVERY_FORMAT = "homeassistant/{}/{}/{}/config"
-TOPIC_DATA_STATE_SUFFIX = "state"
 
 CONFIG_KEY_ADDRESS = "address"
 CONFIG_KEY_PORT = "port"
@@ -107,7 +106,7 @@ class HomeAssistantWarehouse(Warehouse):
             for entityCommand in entity.GetEntityCommands():
                 if entityCommand.HasState():
                     self.client.SendTopicData(
-                        self.MakeEntityCommandStateTopic(entityCommand), 
+                        self.MakeEntityDataTopic(entityCommand), 
                         entityCommand.GetState())
 
     def SendEntityDataConfigurations(self):
@@ -156,7 +155,7 @@ class HomeAssistantWarehouse(Warehouse):
                         data_type, App.getName(), payload['unique_id'].replace(".", "_"))
                 else:  # it's a EntityCommandData
                     if entityData.DoesSupportState():
-                        payload['state_topic'] = self.MakeEntityCommandStateTopic(entityData)
+                        payload['state_topic'] = self.MakeEntityDataTopic(entityData)
                         payload['payload_on'] = PAYLOAD_ON
                         payload['payload_off'] = PAYLOAD_OFF
                     payload['command_topic'] = self.MakeEntityDataTopic(
@@ -218,11 +217,6 @@ class HomeAssistantWarehouse(Warehouse):
         """ Uses MakeValuesTopic but receives an EntityData to manage itself its id, appending a suffix to distinguish
             the extra attrbiutes from the original value """
         return self.MakeValuesTopic(entityData.GetId() + TOPIC_DATA_EXTRA_ATTRIBUTES_SUFFIX)
-
-    def MakeEntityCommandStateTopic(self, entityData):
-        """ Uses MakeValuesTopic but receives an EntityData to manage itself its id,
-            returns state topic"""
-        return self.MakeValuesTopic(f"{entityData.GetId()}/{TOPIC_DATA_STATE_SUFFIX}")
 
     def MakeValuesTopic(self, topic_suffix):
         """ Prepares a topic, including the app name, the client name and finally a passed id """

--- a/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/entities.yaml
+++ b/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/entities.yaml
@@ -50,10 +50,9 @@ Cpu: # if no matches with above CPU patterns, set this
   icon: "mdi:calculator-variant"
 Time:
   icon: "mdi:clock"
-Monitor - turn_all_on:
-  icon: "mdi:monitor-star"
-Monitor - turn_all_off:
-  icon: "mdi:monitor-off"
+Monitor:
+  icon: "mdi:monitor-shimmer"
+  custom_type: switch
 AppInfo:
   icon: "mdi:information-outline"
 Temperature:

--- a/IoTuring/Warehouse/Deployments/MQTTWarehouse/MQTTWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/MQTTWarehouse/MQTTWarehouse.py
@@ -57,19 +57,17 @@ class MQTTWarehouse(Warehouse):
         for entity in self.GetEntities():
             for entitySensor in entity.GetEntitySensors():
                 if entitySensor.HasValue():
-                    self.client.SendTopicData(self.MakeTopic(
-                        entitySensor), entitySensor.GetValue())
+                    self.client.SendTopicData(
+                        self.MakeTopic(entitySensor), 
+                        entitySensor.GetValue())
             for entityCommand in entity.GetEntityCommands():
                 if entityCommand.HasState():
                     self.client.SendTopicData(
-                        self.MakeEntityCommandStateTopic(entityCommand), 
+                        self.MakeTopic(entityCommand), 
                         entityCommand.GetState())
 
     def MakeTopic(self, entityData):
         return MQTTClient.NormalizeTopic(TOPIC_FORMAT.format(App.getName(), self.clientName, entityData.GetId()))
-
-    def MakeEntityCommandStateTopic(self, entityData):
-        return MQTTClient.NormalizeTopic(TOPIC_FORMAT.format(App.getName(), self.clientName, f"{entityData.GetId()}/{TOPIC_DATA_STATE_SUFFIX}"))
 
     def ExportCommandsTopics(self):
         """ Create a file on which I write the Entity command Id and the topic """


### PR DESCRIPTION
With this changes it's now possible to set a state for an EntityCommand, and publish it. In HomeAssistant Switches can show up as a real switch, with correct states. https://www.home-assistant.io/integrations/switch.mqtt/#state_topic

I implemented first for the Monitor entity. Unfortunately on windows you cannot get the states of the monitors, so this only works on linux, with X11. In HA for Windows machines, there is one switch now, with ON and OFF buttons, so only one line on the UI.

Tested on both Windows and Linux.