### PR TITLE
Valueformatter warehouse based

### DIFF
--- a/IoTuring/Configurator/MenuPreset.py
+++ b/IoTuring/Configurator/MenuPreset.py
@@ -98,9 +98,19 @@ class MenuPreset():
             Useful for entities that must have a tag because of their multi-instance possibility """
         self.AddEntry("Tag", "tag", mandatory=True, modify_value_callback=normalize_tag)
 
+
+
+    @staticmethod 
+    def Callback_NormalizeBoolean(value):
+        """ Normalize a boolean value to be used, given a string from user input. To be used as MenuPreset callback. """
+        if value.lower() in BooleanAnswers.TRUE_ANSWERS:
+            return True
+        return False
+
 def normalize_tag(tag):
     """ Normalize a tag to be used safely"""
     return tag.lower().replace(" ", "_")
+
 
 class BooleanAnswers:
     TRUE_ANSWERS = ["y", "yes", "t", "true", "ok", "okay"]  # all lower !

--- a/IoTuring/Entity/Deployments/AppInfo/AppInfo.py
+++ b/IoTuring/Entity/Deployments/AppInfo/AppInfo.py
@@ -34,17 +34,17 @@ class AppInfo(Entity):
             if not new_version: # signal no update and current version (as its the latest)
                 self.SetEntitySensorValue(
                     KEY_UPDATE, False)
-                self.SetEntitySensorExtraAttributes(KEY_UPDATE, {EXTRA_ATTRIBUTE_UPDATE_LATEST: App.getVersion()})
+                self.SetEntitySensorExtraAttribute(KEY_UPDATE, EXTRA_ATTRIBUTE_UPDATE_LATEST, App.getVersion())
             else: # signal update and latest version
                 self.SetEntitySensorValue(
                     KEY_UPDATE, True)
-                self.SetEntitySensorExtraAttributes(KEY_UPDATE, {EXTRA_ATTRIBUTE_UPDATE_LATEST: new_version})
+                self.SetEntitySensorExtraAttribute(KEY_UPDATE, EXTRA_ATTRIBUTE_UPDATE_LATEST, new_version)
         except Exception as e:
             # connection error or pypi name changed or something else
             self.SetEntitySensorValue(
                 KEY_UPDATE, False)
             # add extra attribute to show error message
-            self.SetEntitySensorExtraAttributes(KEY_UPDATE, {EXTRA_ATTRIBUTE_UPDATE_ERROR: GET_UPDATE_ERROR_MESSAGE})
+            self.SetEntitySensorExtraAttribute(KEY_UPDATE, EXTRA_ATTRIBUTE_UPDATE_ERROR, GET_UPDATE_ERROR_MESSAGE)
             
 
     def GetUpdateInformation(self):

--- a/IoTuring/Entity/Deployments/Battery/Battery.py
+++ b/IoTuring/Entity/Deployments/Battery/Battery.py
@@ -11,7 +11,7 @@ class Battery(Entity):
     NAME = "Battery"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_PERCENTAGE, ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_PERCENTAGE, valueFormatterOptions=ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
         
         # Check if charging state working:
         batteryInfo = self.GetBatteryInformation()

--- a/IoTuring/Entity/Deployments/Battery/Battery.py
+++ b/IoTuring/Entity/Deployments/Battery/Battery.py
@@ -11,7 +11,7 @@ class Battery(Entity):
     NAME = "Battery"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_PERCENTAGE))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_PERCENTAGE, ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
         
         # Check if charging state working:
         batteryInfo = self.GetBatteryInformation()
@@ -25,8 +25,7 @@ class Battery(Entity):
 
     def Update(self):
         batteryInfo = self.GetBatteryInformation()
-        self.SetEntitySensorValue(KEY_PERCENTAGE, int(
-            batteryInfo['level']), ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
+        self.SetEntitySensorValue(KEY_PERCENTAGE, int(batteryInfo['level']))
         if isinstance(batteryInfo['charging'], bool):
             self.SetEntitySensorValue(
                 KEY_CHARGING_STATUS, str(batteryInfo['charging']))

--- a/IoTuring/Entity/Deployments/Battery/Battery.py
+++ b/IoTuring/Entity/Deployments/Battery/Battery.py
@@ -1,7 +1,7 @@
 import psutil
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 
 KEY_PERCENTAGE = 'percentage'
 KEY_CHARGING_STATUS = 'charging'
@@ -19,14 +19,14 @@ class Battery(Entity):
             self.RegisterEntitySensor(EntitySensor(self, KEY_CHARGING_STATUS))
 
     def PostInitialize(self):
-        # Check if battery infomration are present
+        # Check if battery information are present
         if not psutil.sensors_battery():
             raise("No battery sensor for this host")
 
     def Update(self):
         batteryInfo = self.GetBatteryInformation()
         self.SetEntitySensorValue(KEY_PERCENTAGE, int(
-            batteryInfo['level']), ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+            batteryInfo['level']), ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
         if isinstance(batteryInfo['charging'], bool):
             self.SetEntitySensorValue(
                 KEY_CHARGING_STATUS, str(batteryInfo['charging']))

--- a/IoTuring/Entity/Deployments/Cpu/Cpu.py
+++ b/IoTuring/Entity/Deployments/Cpu/Cpu.py
@@ -59,33 +59,4 @@ class Cpu(Entity):
                 EntitySensor(self, KEY_AVERAGE_LOAD_LAST_15))
 
     def Update(self):
-        self.SetEntitySensorValue(KEY_PERCENTAGE, psutil.cpu_percent(),
-                                  ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE, 1))
-        self.SetEntitySensorValue(KEY_COUNT, psutil.cpu_count())
-        # CPU times
-        self.SetEntitySensorValue(KEY_TIMES_USER, psutil.cpu_times()[
-            0], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
-        self.SetEntitySensorValue(KEY_TIMES_SYSTEM, psutil.cpu_times()[
-            1], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
-        self.SetEntitySensorValue(KEY_TIMES_IDLE, psutil.cpu_times()[
-            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
-        # CPU stats
-        self.SetEntitySensorValue(KEY_STATS_CTX, psutil.cpu_stats(
-        )[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
-        self.SetEntitySensorValue(KEY_STATS_INTERR, psutil.cpu_stats()[
-                                  1], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
-        # CPU freq
-        self.SetEntitySensorValue(KEY_FREQ_CURRENT, MHZ * psutil.cpu_freq()[
-            0], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-        self.SetEntitySensorValue(KEY_FREQ_MIN, MHZ * psutil.cpu_freq()[
-            1], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-        self.SetEntitySensorValue(KEY_FREQ_MAX, MHZ * psutil.cpu_freq()[
-            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-        if self.os != 'macOS':
-            # CPU avg load
-            self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_1,
-                                      psutil.getloadavg()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
-            self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_5,
-                                      psutil.getloadavg()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
-            self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_15,
-                                      psutil.getloadavg()[2], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
+        pass

--- a/IoTuring/Entity/Deployments/Cpu/Cpu.py
+++ b/IoTuring/Entity/Deployments/Cpu/Cpu.py
@@ -1,5 +1,5 @@
 import psutil
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
 
@@ -60,32 +60,32 @@ class Cpu(Entity):
 
     def Update(self):
         self.SetEntitySensorValue(KEY_PERCENTAGE, psutil.cpu_percent(),
-                                  ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE, 1))
+                                  ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE, 1))
         self.SetEntitySensorValue(KEY_COUNT, psutil.cpu_count())
         # CPU times
         self.SetEntitySensorValue(KEY_TIMES_USER, psutil.cpu_times()[
-            0], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
+            0], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
         self.SetEntitySensorValue(KEY_TIMES_SYSTEM, psutil.cpu_times()[
-            1], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
+            1], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
         self.SetEntitySensorValue(KEY_TIMES_IDLE, psutil.cpu_times()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
+            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_MILLISECONDS))
         # CPU stats
         self.SetEntitySensorValue(KEY_STATS_CTX, psutil.cpu_stats(
-        )[0], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+        )[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
         self.SetEntitySensorValue(KEY_STATS_INTERR, psutil.cpu_stats()[
-                                  1], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+                                  1], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
         # CPU freq
         self.SetEntitySensorValue(KEY_FREQ_CURRENT, MHZ * psutil.cpu_freq()[
-            0], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
+            0], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
         self.SetEntitySensorValue(KEY_FREQ_MIN, MHZ * psutil.cpu_freq()[
-            1], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
+            1], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
         self.SetEntitySensorValue(KEY_FREQ_MAX, MHZ * psutil.cpu_freq()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
+            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
         if self.os != 'macOS':
             # CPU avg load
             self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_1,
-                                      psutil.getloadavg()[0], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+                                      psutil.getloadavg()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
             self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_5,
-                                      psutil.getloadavg()[1], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+                                      psutil.getloadavg()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))
             self.SetEntitySensorValue(KEY_AVERAGE_LOAD_LAST_15,
-                                      psutil.getloadavg()[2], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+                                      psutil.getloadavg()[2], ValueFormatterOptions(ValueFormatterOptions.TYPE_NONE, 2))

--- a/IoTuring/Entity/Deployments/Cpu/Cpu.py
+++ b/IoTuring/Entity/Deployments/Cpu/Cpu.py
@@ -29,52 +29,72 @@ KEY_FREQ_CURRENT = 'current_frequency'
 EXTRA_KEY_FREQ_MIN = 'Minimum CPU frequency'
 EXTRA_KEY_FREQ_MAX = 'Maximum CPU frequency'
 
+VALUEFORMATOPTIONS_CPU_PERCENTAGE = ValueFormatterOptions(
+    ValueFormatterOptions.TYPE_PERCENTAGE, 1)
+VALUEFORMATOPTIONS_CPU_TIME = ValueFormatterOptions(
+    ValueFormatterOptions.TYPE_MILLISECONDS)
+VALUEFORMATOPTIONS_ROUND2 = ValueFormatterOptions(
+    ValueFormatterOptions.TYPE_NONE, 2)
+VALUEFORMATOPTIONS_CPU_FREQUENCY_MHZ = ValueFormatterOptions(
+    ValueFormatterOptions.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz")
+
 
 class Cpu(Entity):
     NAME = "Cpu"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_PERCENTAGE, True))
-        self.RegisterEntitySensor(EntitySensor(self, KEY_FREQ_CURRENT, True))
+        self.RegisterEntitySensor(
+            EntitySensor(
+                self,
+                KEY_PERCENTAGE,
+                valueFormatterOptions=VALUEFORMATOPTIONS_CPU_PERCENTAGE,
+                supportsExtraAttributes=True))
+        self.RegisterEntitySensor(
+            EntitySensor(
+                self,
+                KEY_FREQ_CURRENT,
+                valueFormatterOptions=VALUEFORMATOPTIONS_CPU_FREQUENCY_MHZ,
+                supportsExtraAttributes=True))
 
     def Update(self):
         # CPU Percentage
-        extra_cpu_data = {}
-        self.SetEntitySensorValue(KEY_PERCENTAGE, psutil.cpu_percent(),
-                                  ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE, 1))
+        self.SetEntitySensorValue(KEY_PERCENTAGE, psutil.cpu_percent())
         # Extra data
-        extra_cpu_data[EXTRA_KEY_COUNT] = psutil.cpu_count()
+        self.SetEntitySensorExtraAttribute(
+            KEY_PERCENTAGE, EXTRA_KEY_COUNT, psutil.cpu_count())
         # CPU times
-        extra_cpu_data[EXTRA_KEY_TIMES_USER] = ValueFormatter.GetFormattedValue(psutil.cpu_times()[
-            0], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
-        extra_cpu_data[EXTRA_KEY_TIMES_SYSTEM] = ValueFormatter.GetFormattedValue(psutil.cpu_times()[
-            1], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
-        extra_cpu_data[EXTRA_KEY_TIMES_IDLE] = ValueFormatter.GetFormattedValue(psutil.cpu_times()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_MILLISECONDS))
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_TIMES_USER, psutil.cpu_times()[
+            0], valueFormatterOptions=VALUEFORMATOPTIONS_CPU_TIME)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_TIMES_SYSTEM, psutil.cpu_times()[
+            1], valueFormatterOptions=VALUEFORMATOPTIONS_CPU_TIME)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_TIMES_IDLE, psutil.cpu_times()[
+            2], valueFormatterOptions=VALUEFORMATOPTIONS_CPU_TIME)
         # CPU stats
-        extra_cpu_data[EXTRA_KEY_STATS_CTX] = ValueFormatter.GetFormattedValue(psutil.cpu_stats(
-        )[0], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
-        extra_cpu_data[EXTRA_KEY_STATS_INTERR] = ValueFormatter.GetFormattedValue(psutil.cpu_stats()[
-            1], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_STATS_CTX, psutil.cpu_stats(
+        )[0], valueFormatterOptions=VALUEFORMATOPTIONS_ROUND2)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_STATS_INTERR, psutil.cpu_stats()[
+            1], valueFormatterOptions=VALUEFORMATOPTIONS_ROUND2)
 
         # CPU avg load
-        extra_cpu_data[EXTRA_KEY_AVERAGE_LOAD_LAST_1] = ValueFormatter.GetFormattedValue(
-            psutil.getloadavg()[0], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
-        extra_cpu_data[EXTRA_KEY_AVERAGE_LOAD_LAST_5] = ValueFormatter.GetFormattedValue(
-            psutil.getloadavg()[1], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
-        extra_cpu_data[EXTRA_KEY_AVERAGE_LOAD_LAST_15] = ValueFormatter.GetFormattedValue(
-            psutil.getloadavg()[2], ValueFormatter.Options(ValueFormatter.TYPE_NONE, 2))
-
-        self.SetEntitySensorExtraAttributes(KEY_PERCENTAGE, extra_cpu_data)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_AVERAGE_LOAD_LAST_1,
+                                           psutil.getloadavg()[0], valueFormatterOptions=VALUEFORMATOPTIONS_ROUND2)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_AVERAGE_LOAD_LAST_5,
+                                           psutil.getloadavg()[1], valueFormatterOptions=VALUEFORMATOPTIONS_ROUND2)
+        self.SetEntitySensorExtraAttribute(KEY_PERCENTAGE, EXTRA_KEY_AVERAGE_LOAD_LAST_15,
+                                           psutil.getloadavg()[2], valueFormatterOptions=VALUEFORMATOPTIONS_ROUND2)
 
         # CPU freq
-        extra_cpu_freq_data = {}
-        self.SetEntitySensorValue(KEY_FREQ_CURRENT, MHZ * psutil.cpu_freq()[
-            0], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-        extra_cpu_freq_data[EXTRA_KEY_FREQ_MIN] = ValueFormatter.GetFormattedValue(MHZ * psutil.cpu_freq()[
-            1], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-        extra_cpu_freq_data[EXTRA_KEY_FREQ_MAX] = ValueFormatter.GetFormattedValue(MHZ * psutil.cpu_freq()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_FREQUENCY, FREQUENCY_DECIMALS, "MHz"))
-
-        self.SetEntitySensorExtraAttributes(
-            KEY_FREQ_CURRENT, extra_cpu_freq_data)
+        self.SetEntitySensorValue(
+            KEY_FREQ_CURRENT,
+            value=MHZ * psutil.cpu_freq()[0])
+        # Extra data
+        self.SetEntitySensorExtraAttribute(
+            KEY_FREQ_CURRENT,
+            EXTRA_KEY_FREQ_MIN,
+            value=MHZ * psutil.cpu_freq()[1],
+            valueFormatterOptions=VALUEFORMATOPTIONS_CPU_FREQUENCY_MHZ)
+        self.SetEntitySensorExtraAttribute(
+            KEY_FREQ_CURRENT,
+            EXTRA_KEY_FREQ_MAX,
+            value=MHZ * psutil.cpu_freq()[2],
+            valueFormatterOptions=VALUEFORMATOPTIONS_CPU_FREQUENCY_MHZ)

--- a/IoTuring/Entity/Deployments/Disk/Disk.py
+++ b/IoTuring/Entity/Deployments/Disk/Disk.py
@@ -1,7 +1,7 @@
 import psutil
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 
 KEY_USED_PERCENTAGE = 'space_used_percentage'
 
@@ -18,7 +18,7 @@ class Disk(Entity):
 
     def Update(self):
         self.SetEntitySensorValue(KEY_USED_PERCENTAGE, self.GetDiskUsedPercentage(
-        ), ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+        ), ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
 
     def GetDiskUsedPercentage(self):
         if self.os == 'macOS':

--- a/IoTuring/Entity/Deployments/Disk/Disk.py
+++ b/IoTuring/Entity/Deployments/Disk/Disk.py
@@ -8,13 +8,20 @@ KEY_USED_PERCENTAGE = 'space_used_percentage'
 
 class Disk(Entity):
     NAME = "Disk"
+    DEPENDENCIES = ["Os"]
 
     def Initialize(self):
         self.RegisterEntitySensor(EntitySensor(self, KEY_USED_PERCENTAGE))
+
+    def PostInitialize(self):
+        self.os = self.GetDependentEntitySensorValue('Os', "operating_system")
 
     def Update(self):
         self.SetEntitySensorValue(KEY_USED_PERCENTAGE, self.GetDiskUsedPercentage(
         ), ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
 
     def GetDiskUsedPercentage(self):
-        return psutil.disk_usage('/')[3]
+        if self.os == 'macOS':
+            return psutil.disk_usage('/Users')[3] # macos has a different disk structure
+        else:
+            return psutil.disk_usage('/')[3]

--- a/IoTuring/Entity/Deployments/Disk/Disk.py
+++ b/IoTuring/Entity/Deployments/Disk/Disk.py
@@ -11,7 +11,7 @@ class Disk(Entity):
     DEPENDENCIES = ["Os"]
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_USED_PERCENTAGE, ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_USED_PERCENTAGE, valueFormatterOptions=ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
 
     def PostInitialize(self):
         self.os = self.GetDependentEntitySensorValue('Os', "operating_system")

--- a/IoTuring/Entity/Deployments/Disk/Disk.py
+++ b/IoTuring/Entity/Deployments/Disk/Disk.py
@@ -11,14 +11,13 @@ class Disk(Entity):
     DEPENDENCIES = ["Os"]
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_USED_PERCENTAGE))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_USED_PERCENTAGE, ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE)))
 
     def PostInitialize(self):
         self.os = self.GetDependentEntitySensorValue('Os', "operating_system")
 
     def Update(self):
-        self.SetEntitySensorValue(KEY_USED_PERCENTAGE, self.GetDiskUsedPercentage(
-        ), ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
+        self.SetEntitySensorValue(KEY_USED_PERCENTAGE, self.GetDiskUsedPercentage())
 
     def GetDiskUsedPercentage(self):
         if self.os == 'macOS':

--- a/IoTuring/Entity/Deployments/FileSwitch/FileSwitch.py
+++ b/IoTuring/Entity/Deployments/FileSwitch/FileSwitch.py
@@ -21,7 +21,7 @@ class FileSwitch(Entity):
         except Exception as e:
             raise Exception("Configuration error: " + str(e))
 
-        self.RegisterEntitySensor(EntitySensor(self, KEY_STATE, True))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_STATE, supportsExtraAttributes=True))
         self.RegisterEntityCommand(EntityCommand(
             self, KEY_CMD, self.Callback, KEY_STATE))
 

--- a/IoTuring/Entity/Deployments/FileSwitch/FileSwitch.py
+++ b/IoTuring/Entity/Deployments/FileSwitch/FileSwitch.py
@@ -43,10 +43,8 @@ class FileSwitch(Entity):
     def Update(self):
         self.SetEntitySensorValue(KEY_STATE,
                                   str(Path(self.config_path).exists()))
-        
-        extra = {}
-        extra["Path"] = str(self.config_path)
-        self.SetEntitySensorExtraAttributes(KEY_STATE, extra)
+    
+        self.SetEntitySensorExtraAttribute(KEY_STATE, "Path", str(self.config_path))
 
     @classmethod
     def ConfigurationPreset(self):

--- a/IoTuring/Entity/Deployments/Ram/Ram.py
+++ b/IoTuring/Entity/Deployments/Ram/Ram.py
@@ -6,46 +6,42 @@ from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 # Sensor: Virtual memory
 KEY_MEMORY_PERCENTAGE = 'physical_memory_percentage'
 # Extra data keys
-EXTRA_KEY_MEMORY_TOTAL = 'Physical memory: total [MB]'
-EXTRA_KEY_MEMORY_USED = 'Physical memory: used [MB]'
-EXTRA_KEY_MEMORY_FREE = 'Physical memory: free [MB]'
-EXTRA_KEY_MEMORY_AVAILABLE = 'Physical memory: available [MB]'
+EXTRA_KEY_MEMORY_TOTAL = 'Physical memory: total'
+EXTRA_KEY_MEMORY_USED = 'Physical memory: used'
+EXTRA_KEY_MEMORY_FREE = 'Physical memory: free'
+EXTRA_KEY_MEMORY_AVAILABLE = 'Physical memory: available'
 
 # Sensor: Swap memory
 KEY_SWAP_PERCENTAGE = 'swap_memory_percentage'
 # Extra data keys
-EXTRA_KEY_SWAP_TOTAL = 'Swap memory: total [MB]'
-EXTRA_KEY_SWAP_USED = 'Swap memory: used [MB]'
-EXTRA_KEY_SWAP_FREE = 'Swap memory: free [MB]'
+EXTRA_KEY_SWAP_TOTAL = 'Swap memory: total'
+EXTRA_KEY_SWAP_USED = 'Swap memory: used'
+EXTRA_KEY_SWAP_FREE = 'Swap memory: free'
 
+VALUEFORMATOPTIONS_MEMORY_PERCENTAGE = ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE, 1)
+VALUEFORMATOPTIONS_MEMORY_MB = ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB")
 
 class Ram(Entity):
     NAME = "Ram"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY_MEMORY_PERCENTAGE, True))
-        self.RegisterEntitySensor(EntitySensor(self, KEY_SWAP_PERCENTAGE, True))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_MEMORY_PERCENTAGE, valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_PERCENTAGE, supportsExtraAttributes=True))
+        self.RegisterEntitySensor(EntitySensor(self, KEY_SWAP_PERCENTAGE, valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_PERCENTAGE, supportsExtraAttributes=True))
 
     def Update(self):
         # Virtual memory
-        extra_physical_memory = {}
-        self.SetEntitySensorValue(KEY_MEMORY_PERCENTAGE, psutil.virtual_memory()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+        self.SetEntitySensorValue(KEY_MEMORY_PERCENTAGE, psutil.virtual_memory()[2])
 
         # Extra
-        extra_physical_memory[EXTRA_KEY_MEMORY_TOTAL] = ValueFormatter.GetFormattedValue(psutil.virtual_memory()[0], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        extra_physical_memory[EXTRA_KEY_MEMORY_USED]  = ValueFormatter.GetFormattedValue(psutil.virtual_memory()[3], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        extra_physical_memory[EXTRA_KEY_MEMORY_AVAILABLE]  = ValueFormatter.GetFormattedValue(psutil.virtual_memory()[1], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        extra_physical_memory[EXTRA_KEY_MEMORY_FREE]  = ValueFormatter.GetFormattedValue(psutil.virtual_memory()[4], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorExtraAttributes(KEY_MEMORY_PERCENTAGE, extra_physical_memory)
+        self.SetEntitySensorExtraAttribute(KEY_MEMORY_PERCENTAGE, EXTRA_KEY_MEMORY_TOTAL, psutil.virtual_memory()[0], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
+        self.SetEntitySensorExtraAttribute(KEY_MEMORY_PERCENTAGE, EXTRA_KEY_MEMORY_USED, psutil.virtual_memory()[3], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
+        self.SetEntitySensorExtraAttribute(KEY_MEMORY_PERCENTAGE, EXTRA_KEY_MEMORY_AVAILABLE, psutil.virtual_memory()[1], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
+        self.SetEntitySensorExtraAttribute(KEY_MEMORY_PERCENTAGE, EXTRA_KEY_MEMORY_FREE, psutil.virtual_memory()[4], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
         
         # Swap memory
-        extra_swap_memory = {}
-        self.SetEntitySensorValue(KEY_SWAP_PERCENTAGE, psutil.swap_memory()[
-            3], ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+        self.SetEntitySensorValue(KEY_SWAP_PERCENTAGE, psutil.swap_memory()[3])
         
         # Extra
-        extra_swap_memory[EXTRA_KEY_SWAP_TOTAL] = ValueFormatter.GetFormattedValue(psutil.swap_memory()[0], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        extra_swap_memory[EXTRA_KEY_SWAP_USED]  = ValueFormatter.GetFormattedValue(psutil.swap_memory()[1], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        extra_swap_memory[EXTRA_KEY_SWAP_FREE]  = ValueFormatter.GetFormattedValue(psutil.swap_memory()[2], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorExtraAttributes(KEY_SWAP_PERCENTAGE, extra_swap_memory)
+        self.SetEntitySensorExtraAttribute(KEY_SWAP_PERCENTAGE, EXTRA_KEY_SWAP_TOTAL, psutil.swap_memory()[0], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
+        self.SetEntitySensorExtraAttribute(KEY_SWAP_PERCENTAGE, EXTRA_KEY_SWAP_USED, psutil.swap_memory()[1], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)
+        self.SetEntitySensorExtraAttribute(KEY_SWAP_PERCENTAGE, EXTRA_KEY_SWAP_FREE, psutil.swap_memory()[2], valueFormatterOptions=VALUEFORMATOPTIONS_MEMORY_MB)

--- a/IoTuring/Entity/Deployments/Ram/Ram.py
+++ b/IoTuring/Entity/Deployments/Ram/Ram.py
@@ -1,7 +1,7 @@
 import psutil
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 
 # Virtual memory
 KEY_MEMORY_TOTAL = 'physical_memory_total'
@@ -37,23 +37,23 @@ class Ram(Entity):
     def Update(self):
 
         self.SetEntitySensorValue(KEY_MEMORY_PERCENTAGE, psutil.virtual_memory()[
-            2], ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
         self.SetEntitySensorValue(KEY_SWAP_PERCENTAGE, psutil.swap_memory()[
-            3], ValueFormatter.Options(ValueFormatter.TYPE_PERCENTAGE))
+            3], ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
 
         # Virtual memory
         self.SetEntitySensorValue(KEY_MEMORY_TOTAL,
-                                  psutil.virtual_memory()[0], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+                                  psutil.virtual_memory()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         self.SetEntitySensorValue(KEY_MEMORY_AVAILABLE,
-                                  psutil.virtual_memory()[1], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+                                  psutil.virtual_memory()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         self.SetEntitySensorValue(KEY_MEMORY_USED,
-                                  psutil.virtual_memory()[3], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+                                  psutil.virtual_memory()[3], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         self.SetEntitySensorValue(KEY_MEMORY_FREE,
-                                  psutil.virtual_memory()[4], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+                                  psutil.virtual_memory()[4], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         # Swap memory
         self.SetEntitySensorValue(
-            KEY_SWAP_TOTAL, psutil.swap_memory()[0], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+            KEY_SWAP_TOTAL, psutil.swap_memory()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         self.SetEntitySensorValue(
-            KEY_SWAP_USED,  psutil.swap_memory()[1], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+            KEY_SWAP_USED,  psutil.swap_memory()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
         self.SetEntitySensorValue(
-            KEY_SWAP_FREE, psutil.swap_memory()[2], ValueFormatter.Options(ValueFormatter.TYPE_BYTE, 0, "MB"))
+            KEY_SWAP_FREE, psutil.swap_memory()[2], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))

--- a/IoTuring/Entity/Deployments/Ram/Ram.py
+++ b/IoTuring/Entity/Deployments/Ram/Ram.py
@@ -35,25 +35,4 @@ class Ram(Entity):
         self.RegisterEntitySensor(EntitySensor(self, KEY_SWAP_FREE))
 
     def Update(self):
-
-        self.SetEntitySensorValue(KEY_MEMORY_PERCENTAGE, psutil.virtual_memory()[
-            2], ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
-        self.SetEntitySensorValue(KEY_SWAP_PERCENTAGE, psutil.swap_memory()[
-            3], ValueFormatterOptions(ValueFormatterOptions.TYPE_PERCENTAGE))
-
-        # Virtual memory
-        self.SetEntitySensorValue(KEY_MEMORY_TOTAL,
-                                  psutil.virtual_memory()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorValue(KEY_MEMORY_AVAILABLE,
-                                  psutil.virtual_memory()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorValue(KEY_MEMORY_USED,
-                                  psutil.virtual_memory()[3], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorValue(KEY_MEMORY_FREE,
-                                  psutil.virtual_memory()[4], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        # Swap memory
-        self.SetEntitySensorValue(
-            KEY_SWAP_TOTAL, psutil.swap_memory()[0], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorValue(
-            KEY_SWAP_USED,  psutil.swap_memory()[1], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
-        self.SetEntitySensorValue(
-            KEY_SWAP_FREE, psutil.swap_memory()[2], ValueFormatterOptions(ValueFormatterOptions.TYPE_BYTE, 0, "MB"))
+        pass

--- a/IoTuring/Entity/Deployments/Temperature/Temperature.py
+++ b/IoTuring/Entity/Deployments/Temperature/Temperature.py
@@ -1,7 +1,7 @@
 import psutil
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 
 KEY_SENSOR_FORMAT = "{}"
 FALLBACK_PACKAGE_LABEL = "package_{}"
@@ -77,7 +77,7 @@ class Temperature(Entity):
             if value in self.valid_keys: # in valid_keys I have only the smc keys that returned a value != 0.0
                 # save temperature in the dictionary with key = description
                 values[key] = ioturing_applesmc.get_temperature(value)
-        self.SetEntitySensorValue("cpu", max(values.values()), value_formatter_options=ValueFormatter.Options(decimals=CURRENT_TEMPERATURE_DECIMALS))
+        self.SetEntitySensorValue("cpu", max(values.values()), value_formatter_options=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS))
         self.SetEntitySensorExtraAttributes("cpu", values)
         
         
@@ -108,7 +108,7 @@ class Temperature(Entity):
                 # Set main value = current of the package
                 # TODO Temperature in ValueFormatter
                 self.SetEntitySensorValue(self.packageNameToEntitySensorKey(
-                    package.getLabel()), package.getCurrent(), value_formatter_options=ValueFormatter.Options(decimals=CURRENT_TEMPERATURE_DECIMALS))
+                    package.getLabel()), package.getCurrent(), value_formatter_options=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS))
                 self.SetEntitySensorExtraAttributes(self.packageNameToEntitySensorKey(
                     package.getLabel()), package.getAttributesDict())
             index += 1

--- a/IoTuring/Entity/Deployments/Temperature/Temperature.py
+++ b/IoTuring/Entity/Deployments/Temperature/Temperature.py
@@ -55,7 +55,7 @@ class Temperature(Entity):
         
     def InitmacOS(self):
         import ioturing_applesmc
-        self.RegisterEntitySensor(EntitySensor(self, "cpu", supportsExtraAttributes=True))
+        self.RegisterEntitySensor(EntitySensor(self, "cpu", supportsExtraAttributes=True, valueFormatterOptions=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS)))
         self.valid_keys = []
         # get smc values for all the keys I have in the dictionary and remember
         # the keys that do not return a 0.0 value
@@ -77,7 +77,7 @@ class Temperature(Entity):
             if value in self.valid_keys: # in valid_keys I have only the smc keys that returned a value != 0.0
                 # save temperature in the dictionary with key = description
                 values[key] = ioturing_applesmc.get_temperature(value)
-        self.SetEntitySensorValue("cpu", max(values.values()), value_formatter_options=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS))
+        self.SetEntitySensorValue("cpu", max(values.values()))
         self.SetEntitySensorExtraAttributes("cpu", values)
         
         
@@ -92,9 +92,8 @@ class Temperature(Entity):
             package = psutilTemperaturePackage(pkgName, data)
             if package.hasCurrent():
                 self.registeredPackages.append(package.getLabel())
-                # TODO supportsExtraAttributes only on Linux
                 self.RegisterEntitySensor(EntitySensor(
-                    self, self.packageNameToEntitySensorKey(package.getLabel()), supportsExtraAttributes=True))
+                    self, self.packageNameToEntitySensorKey(package.getLabel()), supportsExtraAttributes=True, valueFormatterOptions=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS)))
             index += 1
             
     def UpdateLinux(self):
@@ -108,7 +107,7 @@ class Temperature(Entity):
                 # Set main value = current of the package
                 # TODO Temperature in ValueFormatter
                 self.SetEntitySensorValue(self.packageNameToEntitySensorKey(
-                    package.getLabel()), package.getCurrent(), value_formatter_options=ValueFormatterOptions(decimals=CURRENT_TEMPERATURE_DECIMALS))
+                    package.getLabel()), package.getCurrent())
                 self.SetEntitySensorExtraAttributes(self.packageNameToEntitySensorKey(
                     package.getLabel()), package.getAttributesDict())
             index += 1

--- a/IoTuring/Entity/Deployments/Uptime/Uptime.py
+++ b/IoTuring/Entity/Deployments/Uptime/Uptime.py
@@ -2,7 +2,7 @@ import psutil
 import time
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Entity.EntityData import EntitySensor
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter, ValueFormatterOptions
 
 KEY = 'uptime'
 
@@ -15,4 +15,4 @@ class Uptime(Entity):
 
     def Update(self):
         self.SetEntitySensorValue(KEY, time.time() - psutil.boot_time(),
-                                  ValueFormatter.Options(ValueFormatter.TYPE_TIME, 0, "m"))
+                                  ValueFormatterOptions(ValueFormatterOptions.TYPE_TIME, 0, "m"))

--- a/IoTuring/Entity/Deployments/Uptime/Uptime.py
+++ b/IoTuring/Entity/Deployments/Uptime/Uptime.py
@@ -11,7 +11,7 @@ class Uptime(Entity):
     NAME = "UpTime"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY, ValueFormatterOptions(ValueFormatterOptions.TYPE_TIME, 0, "m")))
+        self.RegisterEntitySensor(EntitySensor(self, KEY, valueFormatterOptions=ValueFormatterOptions(ValueFormatterOptions.TYPE_TIME, 0, "m")))
 
     def Update(self):
         self.SetEntitySensorValue(KEY, time.time() - psutil.boot_time())

--- a/IoTuring/Entity/Deployments/Uptime/Uptime.py
+++ b/IoTuring/Entity/Deployments/Uptime/Uptime.py
@@ -11,8 +11,7 @@ class Uptime(Entity):
     NAME = "UpTime"
 
     def Initialize(self):
-        self.RegisterEntitySensor(EntitySensor(self, KEY))
+        self.RegisterEntitySensor(EntitySensor(self, KEY, ValueFormatterOptions(ValueFormatterOptions.TYPE_TIME, 0, "m")))
 
     def Update(self):
-        self.SetEntitySensorValue(KEY, time.time() - psutil.boot_time(),
-                                  ValueFormatterOptions(ValueFormatterOptions.TYPE_TIME, 0, "m"))
+        self.SetEntitySensorValue(KEY, time.time() - psutil.boot_time())

--- a/IoTuring/Entity/Deployments/Volume/Volume.py
+++ b/IoTuring/Entity/Deployments/Volume/Volume.py
@@ -16,7 +16,7 @@ class Volume(Entity):
         self.getStateMethod = None
         
         if self.os == "macOS":        
-            self.RegisterEntitySensor(EntitySensor(self, KEY_STATE, False))
+            self.RegisterEntitySensor(EntitySensor(self, KEY_STATE))
             self.RegisterEntityCommand(EntityCommand(
                 self, KEY_CMD, self.CallbackMac, KEY_STATE))
             self.getStateMethod = self.GetVolumeMac

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -107,9 +107,9 @@ class Entity(LogObject):
                 "The Entity sensor you asked for hasn't got extra attributes")
         return self.GetEntitySensorByKey(key).GetExtraAttributes()
 
-    def SetEntitySensorExtraAttributes(self, key, _dict) -> None:
-        """ Set the extra attributes for an entity sensor """
-        self.GetEntitySensorByKey(key).SetExtraAttributes(_dict)
+    def SetEntitySensorExtraAttribute(self, sensorDataKey, name, value, valueFormatterOptions = None) -> None:
+        """ Set the extra attribute for an entity sensor """
+        self.GetEntitySensorByKey(sensorDataKey).SetExtraAttribute(name, value, valueFormatterOptions)
         
     def SetUpdateTimeout(self, timeout) -> None:
         """ Set how much time to wait between 2 updates """

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -87,7 +87,7 @@ class Entity(LogObject):
 
     def SetEntitySensorValue(self, key, value) -> None:
         """ Set the value for an entity sensor """
-        self.GetEntitySensorByKey(key).SetValue(str(value))
+        self.GetEntitySensorByKey(key).SetValue(value)
 
     def GetEntitySensorValue(self, key) -> str:
         """ Get value using its entity sensor key if the value is present (else raise an exception) """

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -1,5 +1,5 @@
 from IoTuring.Entity.EntityManager import EntityManager
-from IoTuring.Entity.ValueFormatter import ValueFormatter
+from IoTuring.Entity.ValueFormat import ValueFormatter
 from IoTuring.Exceptions.Exceptions import UnknownEntityKeyException
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Entity.EntityData import EntitySensor, EntityCommand
@@ -86,7 +86,7 @@ class Entity(LogObject):
         pass
 
     def SetEntitySensorValue(self, key, value, value_formatter_options=None) -> None:
-        """ Set the value for an entity sensor. A value_formatter_options (got from ValueFormatter) can be passed to format the value """
+        """ Set the value for an entity sensor. A value_formatter_options (got from ValueFormatterOptions) can be passed to format the value """
 
         if value_formatter_options is not None:
             value = ValueFormatter.GetFormattedValue(

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -80,21 +80,14 @@ class Entity(LogObject):
             self.Log(self.LOG_ERROR, 'Error occured during update: ' + str(exc))
             # self.entityManager.UnloadEntity(self) # TODO Think how to improve this
 
-    def Update(self):  #
+    def Update(self):
         """ Must be implemented in sub-classes """
         # Can't be called directly, cause stops everything in exception, call only using CallUpdate
         pass
 
-    def SetEntitySensorValue(self, key, value, value_formatter_options=None) -> None:
-        """ Set the value for an entity sensor. A value_formatter_options (got from ValueFormatterOptions) can be passed to format the value """
-
-        if value_formatter_options is not None:
-            value = ValueFormatter.GetFormattedValue(
-                value, value_formatter_options)
-
-        value = str(value)
-
-        self.GetEntitySensorByKey(key).SetValue(value)
+    def SetEntitySensorValue(self, key, value) -> None:
+        """ Set the value for an entity sensor """
+        self.GetEntitySensorByKey(key).SetValue(str(value))
 
     def GetEntitySensorValue(self, key) -> str:
         """ Get value using its entity sensor key if the value is present (else raise an exception) """

--- a/IoTuring/Entity/EntityData.py
+++ b/IoTuring/Entity/EntityData.py
@@ -25,14 +25,22 @@ class EntityData(LogObject):
 
 class EntitySensor(EntityData):
 
-    def __init__(self, entity, key, supportsExtraAttributes = False):
+    def __init__(self, entity, key, valueFormatterOptions=None, supportsExtraAttributes = False):
+        """
+        If supportsExtraAttributes is True, the entity sensor can have extra attributes.
+        valueFormatterOptions is a IoTuring.Entity.ValueFormat.ValueFormatterOptions object.
+        """
         EntityData.__init__(self, entity, key)
         self.supportsExtraAttributes = supportsExtraAttributes
         self.value = None
         self.extraAttributes = None
+        self.valueFormatterOptions = valueFormatterOptions
 
     def DoesSupportExtraAttributes(self):
         return self.supportsExtraAttributes
+
+    def GetValueFormatterOptions(self):
+        return self.valueFormatterOptions
 
     def GetValue(self):
         return self.value

--- a/IoTuring/Entity/EntityData.py
+++ b/IoTuring/Entity/EntityData.py
@@ -63,13 +63,17 @@ class EntitySensor(EntityData):
         """ True if self.extraAttributes isn't empty """
         return self.extraAttributes is not None
     
-    def SetExtraAttributes(self, _dict):
-        # a dict with (attribute_name: value) that is compatible only with certain warehouses
+    def SetExtraAttribute(self, name, value, valueFormatterOptions=None):
         if self.supportsExtraAttributes == False:
             raise Exception("This entity sensor does not support extra attributes. Please specify it when initializing the sensor.")
-        self.extraAttributes = _dict
-
-
+        if self.extraAttributes is None:
+            self.extraAttributes = []
+        # If the Attribute does not already exists, create it, otherwise update it
+        extraAttributeObj = next((attr for attr in self.extraAttributes if attr.GetName() == name), None)
+        if (extraAttributeObj is None):
+            self.extraAttributes.append(ExtraAttribute(name, value, valueFormatterOptions))
+        else:
+            extraAttributeObj.SetValue(value)
 
 class EntityCommand(EntityData):
 
@@ -105,3 +109,24 @@ class EntityCommand(EntityData):
         """ Called only by CallCallback. 
             Run callback for this command, passing the message (a paho.mqtt.client.MQTTMessage) """
         self.callbackFunction(message)
+
+class ExtraAttribute():
+    def __init__(self, name, value, valueFormatterOptions=None):
+        self.name = name
+        self.value = value
+        self.valueFormatterOptions = valueFormatterOptions
+        
+    def GetName(self):
+        return self.name
+    
+    def GetValue(self):
+        return self.value
+    
+    def GetValueFormatterOptions(self):
+        return self.valueFormatterOptions
+    
+    def HasValueFormatterOptions(self):
+        return self.valueFormatterOptions is not None
+    
+    def SetValue(self, value):
+        self.value = value

--- a/IoTuring/Entity/EntityData.py
+++ b/IoTuring/Entity/EntityData.py
@@ -46,8 +46,7 @@ class EntitySensor(EntityData):
         return self.value
 
     def SetValue(self, value):
-        value = str(value)
-        self.Log(self.LOG_DEBUG, "Set to " + value)
+        self.Log(self.LOG_DEBUG, "Set to " + str(value))
         self.value = value
         return self.value
 

--- a/IoTuring/Entity/ValueFormat/ValueFormatter.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatter.py
@@ -10,9 +10,6 @@ from IoTuring.Entity.ValueFormat import ValueFormatterOptions
 # size: MB "means that will be used the specified size 2014Byte->0.001MB"
 # decimals: integer "the number of decimal for the value": -1 for untouched
 
-# TODO Configurable by each warehouse (hardcoded in warehouse and not here, like MQTT true, Hass false)
-ENABLE_UNIT = False
-
 # Lists of measure units
 BYTE_SIZES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 TIME_SIZES = ['s', 'm', 'h', 'd']
@@ -22,10 +19,18 @@ TIME_SIZES_DIVIDERS = [1, 60, 60, 24]
 
 class ValueFormatter():
     
+    # includeUnit: isn't in the option as it's chosen by each warehouse and not by the entity itself
     @staticmethod
-    def GetFormattedValue(value, options: ValueFormatterOptions):
+    def FormatValue(value, options: ValueFormatterOptions, includeUnit: bool):
+        """
+        Format the value according to the options. Returns value as string.
+        IncludeUnit: True if the unit has to be included in the value
+        """
+        return str(ValueFormatter._ParseValue(value, options, includeUnit))
+    
+    def _ParseValue(value, options: ValueFormatterOptions, includeUnit: bool):
         if options is None:
-            return str(value)
+            return value
         
         valueType = options.get_value_type()
         
@@ -33,15 +38,15 @@ class ValueFormatter():
         if valueType == ValueFormatterOptions.TYPE_NONE:  # edit needed only if decimals
             return ValueFormatter.roundValue(value, options)
         elif valueType == ValueFormatterOptions.TYPE_BYTE:
-            return ValueFormatter.ByteFormatter(value, options)
+            return ValueFormatter.ByteFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_MILLISECONDS:
-            return ValueFormatter.MillisecondsFormatter(value, options)
+            return ValueFormatter.MillisecondsFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_TIME:
-            return ValueFormatter.TimeFormatter(value, options)
+            return ValueFormatter.TimeFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_FREQUENCY:
-            return ValueFormatter.FrequencyFormatter(value, options)
+            return ValueFormatter.FrequencyFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_PERCENTAGE:
-            if ENABLE_UNIT:
+            if includeUnit:
                 return str(value) + '%'
             else:
                 return str(value)
@@ -49,7 +54,7 @@ class ValueFormatter():
             return str(value)
 
     @staticmethod
-    def TimeFormatter(value, options: ValueFormatterOptions):
+    def TimeFormatter(value, options: ValueFormatterOptions, includeUnit: bool):
         # Get value in seconds, and adjustable
         asked_size = options.get_adjust_size()
 
@@ -66,25 +71,25 @@ class ValueFormatter():
         value = ValueFormatter.roundValue(value, options)
         result = str(value)
 
-        if ENABLE_UNIT:
+        if includeUnit:
             result = result + TIME_SIZES[index]
 
         return result
 
     @staticmethod
-    def MillisecondsFormatter(value, options: ValueFormatterOptions):
+    def MillisecondsFormatter(value, options: ValueFormatterOptions, includeUnit: bool):
         # Get value in milliseconds: adjust not implemented
         
         value = ValueFormatter.roundValue(value, options)
         
-        if ENABLE_UNIT:
+        if includeUnit:
             return str(value) + 'ms'
         else:
             return str(value)
 
     # Get from number of bytes the correct byte size: 1045B is 1KB. If size_wanted passed and is SIZE_MEGABYTE, if I have 10^9B, I won't diplay 1GB but c.a. 1000MB
     @staticmethod
-    def ByteFormatter(value, options: ValueFormatterOptions):
+    def ByteFormatter(value, options: ValueFormatterOptions, includeUnit: bool):
         # Get value in bytes
         asked_size = options.get_adjust_size()
         decimals = options.get_decimals()
@@ -103,13 +108,13 @@ class ValueFormatter():
 
         result = str(value)
 
-        if ENABLE_UNIT:
+        if includeUnit:
             result = result + BYTE_SIZES[powOf1024]
 
         return result
 
     @staticmethod
-    def FrequencyFormatter(value, options: ValueFormatterOptions):
+    def FrequencyFormatter(value, options: ValueFormatterOptions, includeUnit: bool):
         # Get value in hertz, and adjustable
         asked_size = options.get_adjust_size()
 
@@ -124,7 +129,7 @@ class ValueFormatter():
 
         result = str(value)
         
-        if ENABLE_UNIT:
+        if includeUnit:
             result = result + FREQUENCY_SIZES[index]
         return result
 

--- a/IoTuring/Entity/ValueFormat/ValueFormatter.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatter.py
@@ -31,7 +31,6 @@ class ValueFormatter():
     def _ParseValue(value, options: ValueFormatterOptions, includeUnit: bool):
         if options is None:
             return value
-        
         valueType = options.get_value_type()
         
         # specific type formatting
@@ -148,7 +147,6 @@ class ValueFormatter():
         if includeUnit:
             result = result + CELSIUS_UNIT 
         return result
-
 
     @staticmethod
     def roundValue(value, options: ValueFormatterOptions):

--- a/IoTuring/Entity/ValueFormat/ValueFormatter.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatter.py
@@ -17,6 +17,8 @@ FREQUENCY_SIZES = ['Hz', 'kHz', 'MHz', 'GHz']
 TIME_SIZES_DIVIDERS = [1, 60, 60, 24]
 CELSIUS_UNIT = '°C'
 
+SPACE_BEFORE_UNIT = ' '
+
 class ValueFormatter():
     
     # includeUnit: isn't in the option as it's chosen by each warehouse and not by the entity itself
@@ -48,7 +50,7 @@ class ValueFormatter():
             return ValueFormatter.TemperatureCelsiusFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_PERCENTAGE:
             if includeUnit:
-                return str(value) + '%'
+                return str(value) + SPACE_BEFORE_UNIT + '%'
             else:
                 return str(value)
         else:
@@ -73,7 +75,7 @@ class ValueFormatter():
         result = str(value)
 
         if includeUnit:
-            result = result + TIME_SIZES[index]
+            result = result + SPACE_BEFORE_UNIT + TIME_SIZES[index]
 
         return result
 
@@ -84,7 +86,7 @@ class ValueFormatter():
         value = ValueFormatter.roundValue(value, options)
         
         if includeUnit:
-            return str(value) + 'ms'
+            return str(value) + SPACE_BEFORE_UNIT + 'ms'
         else:
             return str(value)
 
@@ -110,7 +112,7 @@ class ValueFormatter():
         result = str(value)
 
         if includeUnit:
-            result = result + BYTE_SIZES[powOf1024]
+            result = result + SPACE_BEFORE_UNIT + BYTE_SIZES[powOf1024]
 
         return result
 
@@ -131,7 +133,7 @@ class ValueFormatter():
         result = str(value)
         
         if includeUnit:
-            result = result + FREQUENCY_SIZES[index]
+            result = result + SPACE_BEFORE_UNIT + FREQUENCY_SIZES[index]
         return result
 
 
@@ -145,7 +147,7 @@ class ValueFormatter():
         result = str(value)
         
         if includeUnit:
-            result = result + CELSIUS_UNIT 
+            result = result + SPACE_BEFORE_UNIT + CELSIUS_UNIT 
         return result
 
     @staticmethod

--- a/IoTuring/Entity/ValueFormat/ValueFormatter.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatter.py
@@ -15,7 +15,7 @@ BYTE_SIZES = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 TIME_SIZES = ['s', 'm', 'h', 'd']
 FREQUENCY_SIZES = ['Hz', 'kHz', 'MHz', 'GHz']
 TIME_SIZES_DIVIDERS = [1, 60, 60, 24]
-
+CELSIUS_UNIT = '°C'
 
 class ValueFormatter():
     
@@ -45,6 +45,8 @@ class ValueFormatter():
             return ValueFormatter.TimeFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_FREQUENCY:
             return ValueFormatter.FrequencyFormatter(value, options, includeUnit)
+        elif valueType == ValueFormatterOptions.TYPE_TEMPERATURE:
+            return ValueFormatter.TemperatureCelsiusFormatter(value, options, includeUnit)
         elif valueType == ValueFormatterOptions.TYPE_PERCENTAGE:
             if includeUnit:
                 return str(value) + '%'
@@ -132,6 +134,21 @@ class ValueFormatter():
         if includeUnit:
             result = result + FREQUENCY_SIZES[index]
         return result
+
+
+    @staticmethod
+    def TemperatureCelsiusFormatter(value, options: ValueFormatterOptions, includeUnit: bool):
+        # asked_size not implemented
+        
+        # decimals
+        value = ValueFormatter.roundValue(value, options)
+
+        result = str(value)
+        
+        if includeUnit:
+            result = result + CELSIUS_UNIT 
+        return result
+
 
     @staticmethod
     def roundValue(value, options: ValueFormatterOptions):

--- a/IoTuring/Entity/ValueFormat/ValueFormatterOptions.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatterOptions.py
@@ -1,0 +1,33 @@
+class ValueFormatterOptions():  
+    TYPE_NONE = 0
+    TYPE_BYTE = 1
+    TYPE_TIME = 2
+    TYPE_PERCENTAGE = 3
+    TYPE_FREQUENCY = 4
+    TYPE_MILLISECONDS = 5
+
+    DO_NOT_TOUCH_DECIMALS = -1
+      
+    def __init__(self, value_type=TYPE_NONE, decimals=DO_NOT_TOUCH_DECIMALS, adjust_size=None):
+        self.value_type = value_type
+        self.decimals = decimals
+        self.adjust_size = adjust_size
+        
+    def set_value_type(self, value_type):
+        self.value_type = value_type
+        
+    def set_decimals(self, decimals):
+        self.decimals = decimals
+        
+    def set_adjust_size(self, adjust_size):
+        self.adjust_size = adjust_size
+        
+    def get_value_type(self):
+        return self.value_type
+    
+    def get_decimals(self):
+        return self.decimals
+
+    def get_adjust_size(self):
+        return self.adjust_size
+    

--- a/IoTuring/Entity/ValueFormat/ValueFormatterOptions.py
+++ b/IoTuring/Entity/ValueFormat/ValueFormatterOptions.py
@@ -5,6 +5,7 @@ class ValueFormatterOptions():
     TYPE_PERCENTAGE = 3
     TYPE_FREQUENCY = 4
     TYPE_MILLISECONDS = 5
+    TYPE_TEMPERATURE = 6
 
     DO_NOT_TOUCH_DECIMALS = -1
       

--- a/IoTuring/Entity/ValueFormat/__init__.py
+++ b/IoTuring/Entity/ValueFormat/__init__.py
@@ -1,0 +1,2 @@
+from .ValueFormatterOptions import ValueFormatterOptions
+from .ValueFormatter import ValueFormatter

--- a/IoTuring/Warehouse/Deployments/ConsoleWarehouse/ConsoleWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/ConsoleWarehouse/ConsoleWarehouse.py
@@ -1,6 +1,7 @@
 from IoTuring.Logger.Logger import Logger
 from IoTuring.Warehouse.Warehouse import Warehouse
-
+from IoTuring.Entity.ValueFormat import ValueFormatter
+from IoTuring.Entity.EntityData import EntitySensor
 
 class ConsoleWarehouse(Warehouse):
     NAME = "Console"
@@ -10,4 +11,7 @@ class ConsoleWarehouse(Warehouse):
             for entitySensor in entity.GetEntitySensors():
                 if(entitySensor.HasValue()):
                     self.Log(Logger.LOG_MESSAGE, entitySensor.GetId() +
-                             ": " + entitySensor.GetValue())
+                             ": " + self.FormatValue(entitySensor))
+
+    def FormatValue(self, entitySensor: EntitySensor):
+        return ValueFormatter.FormatValue(entitySensor.GetValue(), entitySensor.GetValueFormatterOptions(), True)

--- a/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
@@ -131,8 +131,8 @@ class HomeAssistantWarehouse(Warehouse):
         extraAttributesDict = {}
         extraAttributes = entitySensor.GetExtraAttributes()
         for extraAttribute in extraAttributes:
-            extraAttributesDict[extraAttribute.GetName()] = ValueFormatter.FormatValue(
-                extraAttribute.GetValue(), extraAttribute.GetValueFormatterOptions(), INCLUDE_UNITS_IN_SENSORS)
+            formatted_value = ValueFormatter.FormatValue(extraAttribute.GetValue(), extraAttribute.GetValueFormatterOptions(), INCLUDE_UNITS_IN_EXTRA_ATTRIBUTES)
+            extraAttributesDict[extraAttribute.GetName()] = formatted_value
         return extraAttributesDict
 
     def SendEntityDataConfigurations(self):

--- a/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
@@ -5,11 +5,15 @@ from IoTuring.Protocols.MQTTClient.MQTTClient import MQTTClient
 from IoTuring.Warehouse.Warehouse import Warehouse
 from IoTuring.MyApp.App import App
 from IoTuring.Logger import consts
+from IoTuring.Entity.ValueFormat import ValueFormatter
 
 import json
 import yaml
 import re
 import time
+
+INCLUDE_UNITS_IN_SENSORS = False
+INCLUDE_UNITS_IN_EXTRA_ATTRIBUTES = True
 
 SLEEP_TIME_NOT_CONNECTED_WHILE = 1
 
@@ -116,8 +120,8 @@ class HomeAssistantWarehouse(Warehouse):
             for entitySensor in entity.GetEntitySensors():
                 if (entitySensor.HasValue()):
                     topic = self.MakeEntityDataTopic(entitySensor)
-                    self.client.SendTopicData(
-                        topic, entitySensor.GetValue())  # send
+                    value = ValueFormatter.FormatValue(entitySensor.GetValue(), entitySensor.GetValueFormatterOptions(), INCLUDE_UNITS_IN_SENSORS)
+                    self.client.SendTopicData(topic, value)  # send
                 if (entitySensor.HasExtraAttributes()):
                     self.client.SendTopicData(self.MakeEntityDataExtraAttributesTopic(entitySensor),
                                               json.dumps(entitySensor.GetExtraAttributes()))

--- a/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/HomeAssistantWarehouse/HomeAssistantWarehouse.py
@@ -124,7 +124,16 @@ class HomeAssistantWarehouse(Warehouse):
                     self.client.SendTopicData(topic, value)  # send
                 if (entitySensor.HasExtraAttributes()):
                     self.client.SendTopicData(self.MakeEntityDataExtraAttributesTopic(entitySensor),
-                                              json.dumps(entitySensor.GetExtraAttributes()))
+                                              json.dumps(self.PrepareExtraAttributes(entitySensor)))
+
+    def PrepareExtraAttributes(self, entitySensor):
+        """ Prepare extra attributes to send to HA """
+        extraAttributesDict = {}
+        extraAttributes = entitySensor.GetExtraAttributes()
+        for extraAttribute in extraAttributes:
+            extraAttributesDict[extraAttribute.GetName()] = ValueFormatter.FormatValue(
+                extraAttribute.GetValue(), extraAttribute.GetValueFormatterOptions(), INCLUDE_UNITS_IN_SENSORS)
+        return extraAttributesDict
 
     def SendEntityDataConfigurations(self):
         self.SendLwtSensorConfiguration()

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Like his predecessor - **PyMonitorMQTT** - IoTuring allows you to choose which d
 
 But the most important thing: **works on all OSs and all architectures ! Windows, Linux, macOS, openBSD; x86, amd64, ARM and so on...**
 
+**CHANGELOG**: available in [Releases](https://github.com/richibrics/IoTuring/releases) page
+
 ## Install
 
 ### Who knows how it works

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "IoTuring"
-version = "2023.2.1"
+version = "2023.2.2"
 description = "Simple and powerful cross-platform script to control your pc and share statistics using communication protocols like MQTT and home control hubs like HomeAssistant."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Value now are not formatted each time a sensor is set but from a warehouse when it uses the value.
In this way, each warehouse can set custom options, like to add units to values or to format also value present in extra attributes.

Now value formatter options are define through ValueFormatterOptions object and are set while registering the sensor.

Extra attributes are now object inside a list in an EntitySensor; they can have a ValueFormatterOptions defined while defining the value with SetEntitySensorExtraAttribute that does not accept a dict anymore but name, value, options (now works only with one extra attribute, needs more call for more attributes)