### PR TITLE
Implement Configuration and Log dirs classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ IoTuring/Configurator/dontmoveconf.itg*
 .venv
 build
 *.egg-info
+UserFiles/

--- a/IoTuring/Logger/consts.py
+++ b/IoTuring/Logger/consts.py
@@ -1,5 +1,5 @@
 LOGS_FOLDER = "Logs"
-LOG_FILENAME_FORMAT = "Log_%Y-%m-%d_%H:%M:%S.log"
+LOG_FILENAME_FORMAT = "{}_%Y-%m-%d_%H:%M:%S.log" # first place for App Name
 MESSAGE_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 

--- a/IoTuring/MyApp/App.py
+++ b/IoTuring/MyApp/App.py
@@ -1,5 +1,4 @@
 import inspect
-from IoTuring.Logger.Logger import Logger
 from importlib_metadata import metadata
 import os
 

--- a/IoTuring/MyApp/Directory/ConfigurationsDirectory.py
+++ b/IoTuring/MyApp/Directory/ConfigurationsDirectory.py
@@ -1,0 +1,29 @@
+import os
+from .GetDirectory import GetDirectory
+
+# macOS dep (in PyObjC)
+try:
+    from AppKit import *
+    from Foundation import *
+    macos_support = True
+except:
+    macos_support = False
+
+class ConfigurationsDirectory(GetDirectory):
+    PATH_ENVVAR_NAME = "IOTURING_CONFIG_DIR"  # Environment variable name
+    SUBFOLDER_NAME = "Configurations"  # Subfolder name for configurations in default folder
+    
+    # https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
+    def _macOSFolderPath(self):
+        paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory,NSUserDomainMask,True)
+        basePath = (len(paths) > 0 and paths[0]) or NSTemporaryDirectory()
+        return basePath
+    
+    # https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid
+    def _windowsFolderPath(self):
+        return os.environ["APPDATA"]
+    
+    # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    def _linuxFolderPath(self):
+        return os.environ["XDG_CONFIG_HOME"] if "XDG_CONFIG_HOME" in os.environ else os.path.join(os.environ["HOME"], ".config")
+    

--- a/IoTuring/MyApp/Directory/GetDirectory.py
+++ b/IoTuring/MyApp/Directory/GetDirectory.py
@@ -1,0 +1,94 @@
+import platform
+import os
+import sys
+from importlib_metadata import metadata
+
+
+class GetDirectory():
+    """ Class to get the path to the folder where things are stored in the system.
+        It will try to get the path from the environment variable IOTURING_PATH, if it is not set
+        it will use the default path for the OS.
+        
+        There are 3 os-specific methods to get the default path.
+        
+        Path selection is done in the following order:
+            1. Environment variable
+            2. OS-specific method
+            3. Default path
+        
+        Once the path is obtained, it will be joined with the directory name of the application.
+        
+        e.g.:
+            - by ENVVAR: CHOSEN_PATH 
+            - Windows: C:\\Users\\username\\AppData\\Roaming\\ + IoTuring
+            - macOS: /Users/username/Library/Application Support/ + IoTuring/
+            - Linux: /home/username/.config/ + IoTuring/
+            - if error: default path
+            
+        In addition, if default path is used and SUBFOLDER_NAME is set, it will be joined with the path.
+        
+        e.g.:
+            - by ENVVAR: CHOSEN_PATH - like above
+            - Windows: C:\\Users\\username\\AppData\\Roaming\\ + IoTuring - like above
+            - if error: default path + SUBFOLDER_NAME 
+    """
+            
+    PATH_ENVVAR_NAME = "IOTURING_PATH"  # Environment variable name, default one
+    SUBFOLDER_NAME = None 
+        
+    APP_NAME = metadata('IoTuring')['Name']
+    
+    def getFolderPath(self):
+        """ Returns the path to the folder where the application will store its data. """
+        folderPath = self._defaultFolderPath()
+        try:
+            # Use path from environment variable if present, otherwise os specific folders, otherwise use default path
+            envvarPath = self._envvarFolderPath()
+            if envvarPath is not None:
+                folderPath = envvarPath
+            else:
+                _os = platform.system()
+                if _os == 'Darwin':
+                    folderPath = self._macOSFolderPath()
+                    folderPath = os.path.join(folderPath, self.APP_NAME)
+                elif _os == "Windows":
+                    folderPath = self._windowsFolderPath()        
+                    folderPath = os.path.join(folderPath, self.APP_NAME)
+                elif _os == "Linux":
+                    folderPath = self._linuxFolderPath()
+                    folderPath = os.path.join(folderPath, self.APP_NAME)
+        except:
+            folderPath = self._defaultFolderPath() # default folder path will be used
+                
+        # add slash if missing (for log reasons)
+        if not folderPath.endswith(os.sep):
+            folderPath += os.sep
+        
+        return folderPath
+        
+        
+    def _macOSFolderPath(self):
+        """ Returns the path to the folder where the application will store its data in macOS """
+        raise NotImplementedError("_macOSFolderPath() is not implemented yet")
+        
+    def _windowsFolderPath(self):
+        """ Returns the path to the folder where the application will store its data in Windows """
+        raise NotImplementedError("_windowsFolderPath() is not implemented yet")
+        
+    def _linuxFolderPath(self):
+        """ Returns the path to the folder where the application will store its data in Linux """
+        raise NotImplementedError("_linuxFolderPath() is not implemented yet")
+
+    def _envvarFolderPath(self):
+        """ Returns the path to the folder where the application will store its data from the environment variable; None if not set.
+            The environment variable name must be stored in self.PATH_ENVVAR_NAME """
+        # Get path from environment variable
+        return os.environ.get(self.PATH_ENVVAR_NAME)
+    
+    def _defaultFolderPath(self):
+        """ Returns the path to the folder where the application will store its data in the default path.
+            If not overriden, it will return IoTuring install directory + "UserFiles/" + [SUBFOLDER_NAME if not None]"""
+        if self.SUBFOLDER_NAME is None:
+            return os.path.join(os.path.dirname(os.path.realpath(sys.modules['__main__'].__file__)), "UserFiles")
+        else:
+            return os.path.join(os.path.dirname(os.path.realpath(sys.modules['__main__'].__file__)), "UserFiles", self.SUBFOLDER_NAME)

--- a/IoTuring/MyApp/Directory/LogsDirectory.py
+++ b/IoTuring/MyApp/Directory/LogsDirectory.py
@@ -1,0 +1,26 @@
+import os
+from .GetDirectory import GetDirectory
+
+# macOS dep (in PyObjC)
+try:
+    from AppKit import *
+    from Foundation import *
+    macos_support = True
+except:
+    macos_support = False
+
+class LogsDirectory(GetDirectory):
+    PATH_ENVVAR_NAME = "IOTURING_LOG_DIR"  # Environment variable name
+    SUBFOLDER_NAME = "Logs"  # Subfolder name for configurations in default folder
+    
+    # get the folder where macos stores all the application log files
+    def _macOSFolderPath(self):
+        return os.path.join(NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, True)[0], "Logs")
+    
+    # get the folder where windows stores all the application log files
+    def _windowsFolderPath(self):
+        return os.path.join(os.environ["APPDATA"], "Logs")
+    
+    # get the folder where linux stores all the application log files
+    def _linuxFolderPath(self):
+        return os.path.join(os.environ["HOME"], ".local", "share", "Logs")

--- a/IoTuring/MyApp/Directory/__init__.py
+++ b/IoTuring/MyApp/Directory/__init__.py
@@ -1,0 +1,2 @@
+from .ConfigurationsDirectory import ConfigurationsDirectory
+from .LogsDirectory import LogsDirectory


### PR DESCRIPTION
PR that simplifies the selection of directories based on
- env variable
- os based direcotry
- script folder

The GetDirectory class must be extended and the subclasses only have to specify the methods to retrieve
- macOS path
- windows path
- Linux path

and two variables
- the name for the env variable
- the name for the subfolder that will be used if the selected method is the "script folder" one

Reimplemented Configurations path selection with the new class and implemented the same for Logs