### PR TITLE
Added lock support for KDE plasma

### DIFF
--- a/IoTuring/Entity/Deployments/Lock/Lock.py
+++ b/IoTuring/Entity/Deployments/Lock/Lock.py
@@ -16,7 +16,8 @@ commands = {
     'Linux': {
         'gnome': 'gnome-screensaver-command -l',
         'cinnamon': 'cinnamon-screensaver-command -a',
-        'i3': 'i3lock'
+        'i3': 'i3lock',
+        'plasma': 'loginctl lock-session'
     }
 }
 


### PR DESCRIPTION
Tested on arch. `loginctl lock-session` probably should work on any desktop env, may use it as default fallback command?