### PR TITLE
Open configuration file in editor

### DIFF
--- a/IoTuring/Configurator/Configurator.py
+++ b/IoTuring/Configurator/Configurator.py
@@ -33,14 +33,9 @@ CHOICE_GO_BACK = "< Go back"
 
 class Configurator(LogObject):
 
-    def __init__(self, clear_screen: bool = True) -> None:
+    def __init__(self) -> None:
 
-        if clear_screen:
-            # Clean the screen before first logs:
-            self.pinned_message = False
-            self.ClearScreen(pin_next_message=True)
-        else:
-            self.pinned_message = True
+        self.pinned_message = False
 
         self.configuratorIO = ConfiguratorIO.ConfiguratorIO()
         self.config = self.LoadConfigurations()
@@ -66,7 +61,7 @@ class Configurator(LogObject):
 
                 # Reload config if it was moved:
                 if moveFile:
-                    self.__init__(clear_screen=False)
+                    self.__init__()
 
     def OpenConfigInEditor(self):
         """ Open configuration file in an editor """
@@ -78,7 +73,7 @@ class Configurator(LogObject):
             self.Log(self.LOG_INFO, f"Opening file: \"{config_path}\"")
 
             if OsD.IsWindows():
-                os.startfile(config_path)
+                os.startfile(config_path)  # type: ignore
                 return
             else:
                 editors = [
@@ -95,8 +90,11 @@ class Configurator(LogObject):
 
             self.Log(self.LOG_WARNING, "No editor found")
 
-    def Menu(self) -> None:
+    def Menu(self, clear_screen: bool = True) -> None:
         """ UI for Entities and Warehouses settings """
+
+        if not clear_screen:
+            self.pinned_message = True
 
         mainMenuChoices = [
             {"name": "Manage entities", "value": self.ManageEntities},
@@ -419,7 +417,7 @@ class Configurator(LogObject):
         """
 
         if not self.pinned_message:
-            os.system("cls" if os.name == "nt" else "clear")
+            self.ClearTerminal()
 
         if pin_next_message:
             self.pinned_message = True
@@ -471,3 +469,8 @@ class Configurator(LogObject):
         self.ClearScreen(pin_next_message=True)
         print(message)
         print()
+
+    @staticmethod
+    def ClearTerminal():
+        """Clear the terminal screen on any platform"""
+        os.system("cls" if os.name == "nt" else "clear")

--- a/IoTuring/Configurator/ConfiguratorIO.py
+++ b/IoTuring/Configurator/ConfiguratorIO.py
@@ -66,9 +66,8 @@ class ConfiguratorIO(LogObject):
         try:
             # Use path from environment variable if present, otherwise os specific folders, otherwise use default path
             envvarPath = OsD.GetEnv(CONFIG_PATH_ENV_VAR)
-            if envvarPath:
+            if envvarPath and len(envvarPath) > 0:
                 folderPath = Path(envvarPath)
-
             else:
                 if OsD.IsMacos() and macos_support:
                     folderPath = self.macOSFolderPath().joinpath(self.directoryName)

--- a/IoTuring/Configurator/ConfiguratorIO.py
+++ b/IoTuring/Configurator/ConfiguratorIO.py
@@ -1,16 +1,15 @@
-import platform # Platform detection
-
 import json
-import os  # Configurations file path manipulation, environment variables
-import inspect # Configurations file path manipulation
+from pathlib import Path
+import inspect
 
 from IoTuring.Logger.LogObject import LogObject
-from IoTuring.MyApp.App import App # App name
+from IoTuring.MyApp.App import App  # App name
+from IoTuring.MyApp.SystemConsts import OperatingSystemDetection as OsD
 
 # macOS dep (in PyObjC)
 try:
-    from AppKit import * # type:ignore
-    from Foundation import * # type:ignore
+    from AppKit import *  # type:ignore
+    from Foundation import *  # type:ignore
     macos_support = True
 except:
     macos_support = False
@@ -22,128 +21,137 @@ CONFIGURATION_FILE_NAME = "configurations.json"
 # read ConfiguratorIO.checkConfigurationFileInOldLocation for more information
 DONT_MOVE_FILE_FILENAME = "dontmoveconf.itg"
 
+
 class ConfiguratorIO(LogObject):
     def __init__(self):
         self.directoryName = App.getName()
-    
+
     def readConfigurations(self):
         """ Returns configurations dictionary. If does not exist the file where it should be stored, return None. """
         config = None
         try:
             with open(self.getFilePath(), "r") as f:
                 config = json.loads(f.read())
-            self.Log(self.LOG_MESSAGE, "Loaded \"" + self.getFilePath() + "\"")
+            self.Log(self.LOG_MESSAGE, f"Loaded \"{self.getFilePath()}\"")
         except:
-            self.Log(self.LOG_WARNING, "It seems you don't have a configuration yet. Use configuration mode (-c) to enable your favourite entities and warehouses.\
-                     \nConfigurations will be saved in \"" + self.getFolderPath() + "\"")
+            self.Log(self.LOG_WARNING, f"It seems you don't have a configuration yet. Use configuration mode (-c) to enable your favourite entities and warehouses.\
+                     \nConfigurations will be saved in \"{str(self.getFolderPath())}\"")
         return config
-    
+
     def writeConfigurations(self, data):
         """ Writes configuration data in its file """
         self.createFolderPathIfDoesNotExist()
         with open(self.getFilePath(), "w") as f:
             f.write(json.dumps(data, indent=4))
-        self.Log(self.LOG_MESSAGE, "Saved \"" + self.getFilePath() + "\"")
-        
-    def checkConfigurationFileExists(self):
+        self.Log(self.LOG_MESSAGE, f"Saved \"{str(self.getFilePath())}\"")
+
+    def checkConfigurationFileExists(self) -> bool:
         """ Returns True if the configuration file exists in the correct folder, False otherwise. """
-        return os.path.exists(self.getFilePath()) and os.path.isfile(self.getFilePath())
-    
-    def getFilePath(self):
+        return self.getFilePath().exists() and self.getFilePath().is_file()
+
+    def getFilePath(self) -> Path:
         """ Returns the path to the configurations file. """
-        return os.path.join(self.getFolderPath(), CONFIGURATION_FILE_NAME)
-    
-    def createFolderPathIfDoesNotExist(self):      
+        return self.getFolderPath().joinpath(CONFIGURATION_FILE_NAME)
+
+    def createFolderPathIfDoesNotExist(self):
         """ Check if file exists, if not check if path exists: if not create both folder and file otherwise just the file """
-        if not os.path.exists(self.getFolderPath()):    
-            if not os.path.exists(self.getFolderPath()):
-                os.makedirs(self.getFolderPath())        
-    
-    def getFolderPath(self):
+        if not self.getFolderPath().exists():
+            self.getFolderPath().mkdir()
+
+    def getFolderPath(self) -> Path:
         """ Returns the path to the configurations file. If the directory where the file
             will be stored doesn't exist, it will be created. """
-            
+
         folderPath = self.defaultFolderPath()
         try:
             # Use path from environment variable if present, otherwise os specific folders, otherwise use default path
-            envvarPath = self.envvarFolderPath()
-            if envvarPath is not None:
-                folderPath = envvarPath
+            envvarPath = OsD.GetEnv(CONFIG_PATH_ENV_VAR)
+            if envvarPath:
+                folderPath = Path(envvarPath)
+
             else:
-                _os = platform.system()
-                if _os == 'Darwin' and macos_support:
-                    folderPath = self.macOSFolderPath()
-                    folderPath = os.path.join(folderPath, self.directoryName)
-                elif _os == "Windows":
-                    folderPath = self.windowsFolderPath()        
-                    folderPath = os.path.join(folderPath, self.directoryName)
-                elif _os == "Linux":
-                    folderPath = self.linuxFolderPath()
-                    folderPath = os.path.join(folderPath, self.directoryName)
+                if OsD.IsMacos() and macos_support:
+                    folderPath = self.macOSFolderPath().joinpath(self.directoryName)
+                elif OsD.IsWindows():
+                    folderPath = self.windowsFolderPath().joinpath(self.directoryName)
+                elif OsD.IsLinux():
+                    folderPath = self.linuxFolderPath().joinpath(self.directoryName)
+
         except:
-            pass # default folder path will be used
-        
-        # add slash if missing (for log reasons)
-        if not folderPath.endswith(os.sep):
-            folderPath += os.sep
-            
+            pass  # default folder path will be used
+
         return folderPath
 
-    def defaultFolderPath(self):
-        return os.path.dirname(inspect.getfile(ConfiguratorIO))
-    
+    def defaultFolderPath(self) -> Path:
+        return Path(inspect.getfile(ConfiguratorIO)).parent
+
     # https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
-    def macOSFolderPath(self):
-        paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory,NSUserDomainMask,True) # type: ignore
-        basePath = (len(paths) > 0 and paths[0]) or NSTemporaryDirectory() # type: ignore
-        return basePath
-    
+    def macOSFolderPath(self) -> Path:
+        paths = NSSearchPathForDirectoriesInDomains(  # type: ignore
+            NSApplicationSupportDirectory, NSUserDomainMask, True)  # type: ignore
+        basePath = (len(paths) > 0 and paths[0]) \
+            or NSTemporaryDirectory()  # type: ignore
+        return Path(basePath)
+
     # https://docs.microsoft.com/en-us/windows/win32/shell/knownfolderid
-    def windowsFolderPath(self):
-        return os.environ["APPDATA"]
-    
+    def windowsFolderPath(self) -> Path:
+        return Path(OsD.GetEnv("APPDATA"))
+
     # https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-    def linuxFolderPath(self):
-        return os.environ["XDG_CONFIG_HOME"] if "XDG_CONFIG_HOME" in os.environ else os.path.join(os.environ["HOME"], ".config")
-    
-    def envvarFolderPath(self):
-        return os.getenv(CONFIG_PATH_ENV_VAR)
-    
-    # In versions prior to 2022.12.2, the configurations file was stored in the same folder as this file
-    def oldFolderPath(self):
-        return os.path.dirname(inspect.getfile(ConfiguratorIO))
-    
-    def checkConfigurationFileInOldLocation(self):
-        """ Should be called at the beginning of the program when in -c mode.
-            Checks if a config. file is in the old folder path; if so ask if user wants to copy it
-            into new location, instead of rewriting it from zero.
-            If yes, copy it; otherwise leave it there and write a don't move file to remmeber the 
-            choose in the next times. 
-            This check is not done if old path = current chosen path 
+    def linuxFolderPath(self) -> Path:
+        if OsD.GetEnv("XDG_CONFIG_HOME"):
+            path = Path(OsD.GetEnv("XDG_CONFIG_HOME"))
+        else:
+            path = Path(OsD.GetEnv("HOME")).joinpath(".config")
+        return path
+
+    # In versions prior to 2022.12.2, the configurations file was stored in the same folder as this file:
+    def oldFolderPath(self) -> Path:
+        return self.defaultFolderPath()
+
+    def shouldMoveOldConfig(self) -> bool:
+        """ Checks if a config file is in the old folder path and should be moved to the new location.
+
+        Returns:
+            bool: True if the config should be moved. False if old path = current chosen path or should not be moved
         """
-        
-        # This check is not done if old path = current chosen path (also check if ending slash is present)
-        if self.oldFolderPath() == self.getFolderPath() or self.oldFolderPath() == self.getFolderPath()[:-1]:
-            return
-        
-        # Exit check if no config. in old directory or if there is also the dont move file with it.
-        configuration_file_exists = os.path.exists(os.path.join(self.oldFolderPath(), CONFIGURATION_FILE_NAME))
-        dont_move_file_exists = os.path.exists(os.path.join(self.oldFolderPath(), DONT_MOVE_FILE_FILENAME))
-        if not configuration_file_exists or (configuration_file_exists and dont_move_file_exists):
-            return
-        
-        response = input("A configuration file was found in the old location. Do you want to move it to the new location ? if not, a new blank configuration will be used (y/n): ")
-        response = bool( response.lower() == "y")
-        # Then ask to move it
-        if response:
+
+        # This check is not done if old path = current chosen path:
+        if self.oldFolderPath() == self.getFolderPath():
+            return False
+
+        # Old config does not exist:
+        if not self.oldFolderPath().joinpath(CONFIGURATION_FILE_NAME).exists():
+            return False
+        # Old config and dont move file exists:
+        elif self.oldFolderPath().joinpath(DONT_MOVE_FILE_FILENAME).exists():
+            return False
+
+        return True
+
+    def manageOldConfig(self, moveFile: bool) -> None:
+        """Move config file from old location, or create dontmove file
+
+        Args:
+            moveFile (bool): True: move the file. False: Create dontmove file
+        """
+
+        if moveFile:
             # create folder if not exists
             self.createFolderPathIfDoesNotExist()
             # copy file from old to new location
-            os.rename(os.path.join(self.oldFolderPath(), CONFIGURATION_FILE_NAME), os.path.join(self.getFolderPath(), CONFIGURATION_FILE_NAME))
-            self.Log(self.LOG_MESSAGE, "Copied into \"" + os.path.join(self.getFolderPath(), CONFIGURATION_FILE_NAME) + "\"")
+            self.oldFolderPath().joinpath(CONFIGURATION_FILE_NAME).rename(self.getFilePath())
+            self.Log(self.LOG_MESSAGE,
+                     f"Copied to \"{str(self.getFilePath())}\"")
         else:
             # create dont move file
-            with open(os.path.join(self.oldFolderPath(), DONT_MOVE_FILE_FILENAME), "w") as f:
-                f.write("This file is here to remember you that you don't want to move the configuration file into the new location. If you want to move it, delete this file and \
-                    run the script in -c mode.")
-            self.Log(self.LOG_MESSAGE, "You won't be asked again. A new blank configuration will be used; if you want to move the existing configuration file, delete \"" + os.path.join(self.oldFolderPath(), DONT_MOVE_FILE_FILENAME) + "\" and run the script in -c mode.")
+            with open(self.oldFolderPath().joinpath(DONT_MOVE_FILE_FILENAME), "w") as f:
+                f.write(" ".join([
+                    "This file is here to remember you that you don't want to move the configuration file into the new location.",
+                    "If you want to move it, delete this file and run the script in -c mode."
+                ]))
+            self.Log(self.LOG_MESSAGE, " ".join([
+                "You won't be asked again. A new blank configuration will be used;",
+                f"if you want to move the existing configuration file, delete \"{self.oldFolderPath().joinpath(DONT_MOVE_FILE_FILENAME)}",
+                "and run the script in -c mode."
+            ]))

--- a/IoTuring/Exceptions/Exceptions.py
+++ b/IoTuring/Exceptions/Exceptions.py
@@ -8,3 +8,9 @@ class UserCancelledException(Exception):
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
         self.message = "User cancelled the ongoing process"
+
+
+class UnknownLoglevelException(Exception):
+    def __init__(self, loglevel: str) -> None:
+        super().__init__(f"Unknown log level: {loglevel}")
+        self.loglevel = loglevel

--- a/IoTuring/Logger/LogLevel.py
+++ b/IoTuring/Logger/LogLevel.py
@@ -1,5 +1,6 @@
 from IoTuring.Logger import consts
 from IoTuring.Logger.Colors import Colors
+from IoTuring.Exceptions.Exceptions import UnknownLoglevelException
 
 
 class LogLevel:
@@ -10,7 +11,7 @@ class LogLevel:
             (l for l in consts.LOG_LEVELS if l["const"] == level_const), None)
 
         if not level_dict:
-            raise Exception(f"Unknown log level: {level_const}")
+            raise UnknownLoglevelException(level_const)
 
         self.const = level_const
         self.string = level_dict["string"]

--- a/IoTuring/MyApp/App.py
+++ b/IoTuring/MyApp/App.py
@@ -1,4 +1,4 @@
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 
 class App():
     METADATA = metadata('IoTuring')
@@ -12,8 +12,9 @@ class App():
     # "Project-URL": "documentation, https://github.com/richibrics/IoTuring",
     # "Project-URL": "repository, https://github.com/richibrics/IoTuring",
     # "Project-URL": "changelog, https://github.com/richibrics/IoTuring/releases",
-    URL_HOMEPAGE = METADATA.get_all("Project-URL")[0].split(', ')[1].strip()
-    URL_RELEASES = METADATA.get_all("Project-URL")[-1].split(', ')[1].strip()
+    URLS = METADATA.get_all("Project-URL") or ""
+    URL_HOMEPAGE = URLS[0].split(', ')[1].strip()
+    URL_RELEASES = URLS[-1].split(', ')[1].strip()
 
     @staticmethod
     def getName() -> str:

--- a/IoTuring/MyApp/SystemConsts/OperatingSystemDetection.py
+++ b/IoTuring/MyApp/SystemConsts/OperatingSystemDetection.py
@@ -6,10 +6,15 @@ import shutil
 class OperatingSystemDetection():
     OS_NAME = platform.system()
     
-    # Fixed list:
+    # Values to return as OS:
     MACOS = "macOS"
     WINDOWS = "Windows"
     LINUX = "Linux"
+
+    # Values to use to detect the OS:
+    MACOS_DETECTION_NAMES = ["macOS", "Darwin"]
+    WINDOWS_DETECTION_NAMES = ["Windows"]
+    LINUX_DETECTION_NAMES = ["Linux"]
 
 
     @classmethod
@@ -26,15 +31,15 @@ class OperatingSystemDetection():
 
     @classmethod
     def IsLinux(cls) -> bool:
-        return bool(cls.OS_NAME == cls.LINUX)
+        return bool(cls.OS_NAME in cls.LINUX_DETECTION_NAMES)
     
     @classmethod
     def IsWindows(cls) -> bool:
-        return bool(cls.OS_NAME == cls.WINDOWS)
+        return bool(cls.OS_NAME in cls.WINDOWS_DETECTION_NAMES)
 
     @classmethod
     def IsMacos(cls) -> bool:
-        return bool(cls.OS_NAME == cls.MACOS)
+        return bool(cls.OS_NAME in cls.MACOS_DETECTION_NAMES)
 
     @classmethod
     def GetEnv(cls, envvar) -> str:

--- a/IoTuring/MyApp/SystemConsts/OperatingSystemDetection.py
+++ b/IoTuring/MyApp/SystemConsts/OperatingSystemDetection.py
@@ -39,22 +39,17 @@ class OperatingSystemDetection():
     @classmethod
     def GetEnv(cls, envvar) -> str:
         """Get envvar, also from different tty on linux"""
-        env_value = ""
-        if cls.IsLinux():
-            e = os.environ.get(envvar)
-            if not e:
-                try:
-                    # Try if there is another tty with gui:
-                    session_pid = next((u.pid for u in psutil.users() if u.host and "tty" in u.host), None) 
-                    if session_pid:
-                        p = psutil.Process(int(session_pid))
-                        with p.oneshot():
-                            env_value = p.environ()[envvar]
-                except KeyError:
-                    env_value = ""
-            else:
-                env_value = e
-
+        env_value = os.environ.get(envvar) or ""
+        if cls.IsLinux() and not env_value:
+            try:
+                # Try if there is another tty with gui:
+                session_pid = next((u.pid for u in psutil.users() if u.host and "tty" in u.host), None) 
+                if session_pid:
+                    p = psutil.Process(int(session_pid))
+                    with p.oneshot():
+                        env_value = p.environ()[envvar]
+            except KeyError:
+                env_value = ""
         return env_value
             
     @staticmethod

--- a/IoTuring/__init__.py
+++ b/IoTuring/__init__.py
@@ -44,6 +44,9 @@ def loop():
         parser.print_help()
         os._exit(0)
 
+    # Clear the terminal
+    Configurator.ClearTerminal()
+
     # Start logger:
     logger = Logger()
     configurator = Configurator()
@@ -55,7 +58,7 @@ def loop():
             # Check old location:
             configurator.CheckFile()
 
-            configurator.Menu()
+            configurator.Menu(clear_screen=False)
         except KeyboardInterrupt:
             logger.Log(Logger.LOG_WARNING, "Configurator",
                        "Configuration NOT saved")

--- a/IoTuring/__init__.py
+++ b/IoTuring/__init__.py
@@ -6,31 +6,64 @@ from IoTuring.Configurator.ConfiguratorLoader import ConfiguratorLoader
 from IoTuring.Entity.EntityManager import EntityManager
 from IoTuring.Logger.Logger import Logger
 from IoTuring.Logger.Colors import Colors
-import sys
 import signal
 import os
 import time
+import argparse
 
 warehouses = []
 entities = []
 
 
 def loop():
-    
+
+    parser = argparse.ArgumentParser(
+        prog=App.getName(),
+        description=App.getDescription(),
+        epilog="Start without argument for normal use"
+    )
+
+    parser.add_argument("-v", "--version",
+                        action="version",
+                        version=f"{App.getName()} {App.getVersion()}"
+                        )
+
+    parser.add_argument("-c", "--configurator",
+                        help="enter configuration mode",
+                        action="store_true")
+
+    parser.add_argument("-o", "--open-config",
+                        help="open config file",
+                        action="store_true")
+
+    args = parser.parse_args()
+
+    # Only one argument should be used:
+    if all(vars(args).values()):
+        print("error: use only one option!", end="\n\n")
+        parser.print_help()
+        os._exit(0)
+
     # Start logger:
     logger = Logger()
     configurator = Configurator()
 
-    # add -c to configure with the menu
-    if len(sys.argv) > 1 and sys.argv[1] == "-c":
-        if not configurator.configuratorIO.checkConfigurationFileExists(): 
-            # If the file doesn't exist, check if it's in the old location
-            configurator.configuratorIO.checkConfigurationFileInOldLocation()
+    logger.Log(Logger.LOG_DEBUG, "App", f"Selected options: {vars(args)}")
+
+    if args.configurator:
         try:
+            # Check old location:
+            configurator.CheckFile()
+
             configurator.Menu()
         except KeyboardInterrupt:
-            logger.Log(Logger.LOG_WARNING, "Configurator", "Configuration NOT saved")
+            logger.Log(Logger.LOG_WARNING, "Configurator",
+                       "Configuration NOT saved")
             Exit_SIGINT_handler()
+
+    elif args.open_config:
+        configurator.OpenConfigInEditor()
+        os._exit(0)
 
     # This have to start after configurator.Menu(), otherwise won't work starting from the menu
     signal.signal(signal.SIGINT, Exit_SIGINT_handler)
@@ -39,7 +72,6 @@ def loop():
     logger.Log(Logger.LOG_INFO, "Configurator",
                "Run the script with -c to enter configuration mode")
 
-    
     eM = EntityManager()
 
     # These will be done from the configuration reader
@@ -63,24 +95,27 @@ def loop():
     # on Windows a SIGINT signal can't be catched otherwise.
     # Daemon mode involves thread exit when main ends. So
     # I need main to never end
-    while(True):
+    while (True):
         time.sleep(1)
+
 
 def Exit_SIGINT_handler(sig=None, frame=None):
     logger = Logger()
-    logger.Log(Logger.LOG_INFO, "Main", "Application closed by SigInt", printToConsole=False) # to file
-    
+    logger.Log(Logger.LOG_INFO, "Main", "Application closed by SigInt",
+               printToConsole=False)  # to file
+
     messages = ["Exiting...",
                 "Thanks for using IoTuring !"]
-    print("") # New line
+    print()  # New line
     for message in messages:
         text = ""
-        if(Logger.checkTerminalSupportsColors()):
+        if (Logger.checkTerminalSupportsColors()):
             text += Colors.cyan
-        text += message 
-        if(Logger.checkTerminalSupportsColors()):
+        text += message
+        if (Logger.checkTerminalSupportsColors()):
             text += Colors.reset
-        logger.Log(Logger.LOG_INFO, "Main", text, writeToFile=False) # to terminal
-        
+        logger.Log(Logger.LOG_INFO, "Main", text,
+                   writeToFile=False)  # to terminal
+
     logger.CloseFile()
     os._exit(0)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ But the most important thing: **works on all OSs and all architectures ! Windows
 
 ### Who knows how it works
 
-Using pip (on Python >= 3.7) install the IoTuring package
+Using pip (on Python >= 3.8) install the IoTuring package
 
 ```shell
 pip install IoTuring
@@ -38,7 +38,7 @@ Configure with `IoTuring -c` or `python -m IoTuring -c`
 
 #### Requirements
 
-- [Python 3.7+](https://www.python.org/downloads/)
+- [Python 3.8+](https://www.python.org/downloads/)
 - [Pip](https://www.makeuseof.com/tag/install-pip-for-python/)
 
 Some platforms may need other software for some entities.
@@ -109,7 +109,7 @@ python -m IoTuring
 Run the configurator:
 
 ```shell
-docker run -it -v ./.config/IoTuring/:/config ghcr.io/richibrics/ioturing:latest IoTuring -c
+docker run -it -v ./.config/IoTuring/:/config richibrics/ioturing:latest IoTuring -c
 ```
 
 Enable the `Console Warehouse` to see logs!
@@ -117,7 +117,7 @@ Enable the `Console Warehouse` to see logs!
 Run detached after configuration:
 
 ```shell
-docker run -d -v ./.config/IoTuring/:/config ghcr.io/richibrics/ioturing:latest
+docker run -d -v ./.config/IoTuring/:/config richibrics/ioturing:latest
 ```
 
 For a docker compose example see [docker-compose.yaml](./docker-compose.yaml). Create configuration manually or with the command above!
@@ -163,7 +163,7 @@ All sensors and switches will be available to be added to your dashboard in your
 | Volume             | control audio volume                                                        | ![mac](https://raw.githubusercontent.com/richibrics/IoTuring/main/docs/images/mac.png) ![linux](https://raw.githubusercontent.com/richibrics/IoTuring/main/docs/images/linux.png)                                                             |
 
 
-\* To use the features from Power entity on Linux and macOS you need to give permissions to your user to shutdown and reboot without sudo password.
+\* To use the features from Power entity on macOS and on some Linux distros you need to give permissions to your user to shutdown and reboot without sudo password.
 You can easily do that by using the following terminal command:
 
 ```shell

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,8 @@
 services:
   ioturing:
-    image: ghcr.io/richibrics/ioturing:latest
+    image: richibrics/ioturing:latest
+    # Or from Github:
+    # image: ghcr.io/richibrics/ioturing:latest
     container_name: ioturing
     volumes:
       - ~/.config/IoTuring/:/config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "IoTuring"
 version = "2023.11.1"
 description = "Simple and powerful cross-platform script to control your pc and share statistics using communication protocols like MQTT and home control hubs like HomeAssistant."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "COPYING"}
 keywords = ["iot","mqtt","monitor"]
 authors = [
@@ -24,8 +24,7 @@ dependencies = [
   "paho-mqtt",
   "psutil",
   "PyYAML",
-  "importlib_metadata",
-  "requests",
+    "requests",
   "InquirerPy",
   "PyObjC; sys_platform == 'darwin'",
   "IoTuring-applesmc; sys_platform == 'darwin'",


### PR DESCRIPTION
- Use `argparse` library for argument parsing: Easier to add new options, version info and help:

```
> IoTuring --help
usage: IoTuring [-h] [-v] [-c] [-o]

Simple and powerful cross-platform script to control your pc and share statistics using communication protocols like MQTT and home control hubs like HomeAssistant.

options:
  -h, --help          show this help message and exit
  -v, --version       show program's version number and exit
  -c, --configurator  enter configuration mode
  -o, --open-config   open config file

Start without argument for normal use
> IoTuring --version
IoTuring 2023.11.1
```

- New start argument: `-o, --open-config`: Open config file
Maybe help with #85
On windows it opens in the editor associated with json files. On Mac and Linux it tries the following editors in this order:
  - What set in the `$EDITOR` envvar
  - `nano`
  - `vim`

@richibrics Please check if this is working on Mac. I know `nano` is installed on recent MacOS versions by default


Other changes:

- Update minimum Python version to 3.8, as 3.7 is EOL: https://devguide.python.org/versions/
- `importlib.metadata` is available as a std lib in 3.8, so `importlib_metadata` backport is not needed anymore
- Use Dockerhub links in readme and compose, instead of ghcr. It's shorter, and looks better
- `ConfiguratorIO`: Menu for old configuration moved to `Configurator`, modernize, use Pathlib.
- `Configurator`: small changes, when to clear the screen
- Log related: 
  - Catch exception for wrong loglevel from envvar. 
  - Store envvar loglevel (Previously each log line asked for the envvar. I guess this should be some performance improvement)
- `OperatingSystemDetection`: `OsD.GetEnv()` now works on every platform, not just on Linux :)

Tested on Linux and Windows