### PR TITLE
Fix logger encoding, forcing utf-8

### DIFF
--- a/IoTuring/Logger/Logger.py
+++ b/IoTuring/Logger/Logger.py
@@ -155,7 +155,7 @@ class Logger(LogLevelObject, metaclass=Singleton):
 
     def GetLogFileDescriptor(self) -> TextIOWrapper:
         if self.log_file_descriptor is None:
-            self.log_file_descriptor = open(self.log_filename, "a")
+            self.log_file_descriptor = open(self.log_filename, "a", encoding="utf-8")
 
         return self.log_file_descriptor
 


### PR DESCRIPTION
In some scenarios, an exception was occurring in the logger with the message `UnicodeEncodeError: 'charmap' codec can't encode characters in position XX-YY....`. Fortunately, this situation only resulted in the logger being blocked without further consequences. To address this minor inconvenience, I have made a modification to the `logger.py` file at [`line 158`](https://github.com/SiriosDev/IoTuring/blob/b35452ba3bbfe35f83e065ca834b9ed764b583cd/IoTuring/Logger/Logger.py#158), where the log file is generated. The implementation now forcefully utilizes an appropriate encoding, thereby mitigating the exception issue and ensuring a more stable operation of the logger.
