### PR TITLE
Repostats action only on main repo, sys.exit(), ConfiguratorIO error handling, utf-8 configuration file

### DIFF
--- a/.github/workflows/repostats.yml
+++ b/.github/workflows/repostats.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   j1:
     name: repostats-for-nice-project
+    if: github.repository == 'richibrics/IoTuring'
     runs-on: ubuntu-latest
     steps:
       - name: run-ghrs

--- a/IoTuring/Configurator/Configurator.py
+++ b/IoTuring/Configurator/Configurator.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import shutil
+import sys
 
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Exceptions.Exceptions import UserCancelledException
@@ -180,7 +181,7 @@ class Configurator(LogObject):
     def Quit(self) -> None:
         """ Save configurations and quit """
         self.WriteConfigurations()
-        exit(0)
+        sys.exit(0)
 
     def LoadConfigurations(self) -> dict:
         """ Reads the configuration file and returns configuration dictionary.

--- a/IoTuring/Configurator/ConfiguratorLoader.py
+++ b/IoTuring/Configurator/ConfiguratorLoader.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import sys
+
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Configurator.Configurator import KEY_ENTITY_TYPE, Configurator, KEY_ACTIVE_ENTITIES, KEY_ACTIVE_WAREHOUSES, KEY_WAREHOUSE_TYPE
@@ -20,7 +22,7 @@ class ConfiguratorLoader(LogObject):
         if not KEY_ACTIVE_WAREHOUSES in self.configurations:
             self.Log(
                 self.LOG_ERROR, "You have to enable at least one warehouse: configure it using -c argument")
-            exit(1)
+            sys.exit("No warehouse enabled")
         for activeWarehouse in self.configurations[KEY_ACTIVE_WAREHOUSES]:
             # Get WareHouse named like in config type field, then init it with configs and add it to warehouses list
             whClass = wcm.GetClassFromName(
@@ -43,7 +45,7 @@ class ConfiguratorLoader(LogObject):
         if not KEY_ACTIVE_ENTITIES in self.configurations:
             self.Log(
                 self.LOG_ERROR, "You have to enable at least one entity: configure it using -c argument")
-            exit(1)
+            sys.exit("No entity enabled")
         for activeEntity in self.configurations[KEY_ACTIVE_ENTITIES]:
             entityClass = ecm.GetClassFromName(activeEntity[KEY_ENTITY_TYPE])
             if entityClass is None:

--- a/IoTuring/__init__.py
+++ b/IoTuring/__init__.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 
+import signal
+import sys
+import time
+import argparse
+
 from IoTuring.MyApp.App import App
 from IoTuring.Configurator.Configurator import Configurator
 from IoTuring.Configurator.ConfiguratorLoader import ConfiguratorLoader
 from IoTuring.Entity.EntityManager import EntityManager
 from IoTuring.Logger.Logger import Logger
 from IoTuring.Logger.Colors import Colors
-import signal
-import os
-import time
-import argparse
 
 warehouses = []
 entities = []
@@ -40,9 +41,9 @@ def loop():
 
     # Only one argument should be used:
     if all(vars(args).values()):
-        print("error: use only one option!", end="\n\n")
         parser.print_help()
-        os._exit(0)
+        print()
+        sys.exit("Error: Invalid arguments!")
 
     # Clear the terminal
     Configurator.ClearTerminal()
@@ -66,7 +67,7 @@ def loop():
 
     elif args.open_config:
         configurator.OpenConfigInEditor()
-        os._exit(0)
+        sys.exit(0)
 
     # This have to start after configurator.Menu(), otherwise won't work starting from the menu
     signal.signal(signal.SIGINT, Exit_SIGINT_handler)
@@ -121,4 +122,4 @@ def Exit_SIGINT_handler(sig=None, frame=None):
                    writeToFile=False)  # to terminal
 
     logger.CloseFile()
-    os._exit(0)
+    sys.exit(0)


### PR DESCRIPTION
- Repostats action nags me to set up a token, and I don't care :) Also there is no traffic on forks, so it doesn't make any sense to run it everywhere. With this change it will only run on your main repo, not on forks.
- [According to some tutorials](https://www.geeksforgeeks.org/python-exit-commands-quit-exit-sys-exit-and-os-_exit/) `sys.exit()` is the recommended way to terminate the application nowadays, changed to it everywhere. If you put anything in the argument of `sys.exit()` the exit code will be 1, and the exit message is printed to the terminal, very nice!
- Error handling in ConfiguratorIO, now catches exceptions correctly.
- Configuration file is saved as utf-8: `json.dumps(ensure_ascii=False)` was the solution. It's much easier to edit the config file manually this way, if your language uses non ascii letters, like Hungarian do.