### PR TITLE
Cap Paho-mqtt version below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "paho-mqtt",
+  "paho-mqtt<2.0.0",
   "psutil",
   "PyYAML",
     "requests",


### PR DESCRIPTION
With this change the maximum version for paho-mqtt will be 1.6.1. New installs won't fail at least.

This is a temporary fix and paho-mqtt 2.0 should be implemented in the near future, related issue shouldn't be closed yet: #97 