### PR TITLE
ClassManager Rewrite

### DIFF
--- a/IoTuring/ClassManager/ClassManager.py
+++ b/IoTuring/ClassManager/ClassManager.py
@@ -1,56 +1,104 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from os import path
 import importlib.util
 import importlib.machinery
 import sys
 import inspect
+from pathlib import Path
+
 from IoTuring.Logger.LogObject import LogObject
-
-# from IoTuring.ClassManager import consts
-
-# This is a parent class
-
-# Implement subclasses in this way:
-
-# def __init__(self):
-#     ClassManager.__init__(self)
-#     self.baseClass = Entity  : Select the class to find
-#     self.GetModulesFilename(consts.ENTITIES_PATH)  : Select path where it should look for classes and add all classes to found list
-
-# This class is used to find and load classes without importing them
-# The important this is that the class is inside a folder that exactly the same name of the Class and of the file (obviously not talking about extensions)
+from IoTuring.MyApp.App import App
 
 
 class ClassManager(LogObject):
-    def __init__(self):
-        self.modulesFilename = []
-        module_path = sys.modules[self.__class__.__module__].__file__
-        if not module_path:
-            raise Exception("Error getting path: " + str(module_path))
+    """Base class for ClassManagers
+
+    This class is used to find and load classes without importing them
+    The important this is that the class is inside a folder that exactly the same name of the Class and of the file (obviously not talking about extensions)
+    """
+
+    # Set up these class variables in subclasses:
+    classesRelativePath = None  # Change in subclasses!
+
+    def __init__(self) -> None:
+
+        # Store loaded classes here:
+        self.loadedClasses = []
+
+        # Collect paths
+        self.moduleFilePaths = self.GetModuleFilePaths()
+
+    def GetModuleFilePaths(self) -> list[Path]:
+        """Get the paths of of python files of this class
+
+        Raises:
+            Exception: If path not defined or exists
+            FileNotFoundError: No module in the dir
+
+        Returns:
+            list[Path]: List of paths of python files
+        """
+
+        if not self.classesRelativePath:
+            raise Exception("Path to deployments not defined")
+
+        # Get the absolute path of the dir of files:
+        classesRootPath = App.getRootPath().joinpath(self.classesRelativePath)
+
+        if not classesRootPath.exists:
+            raise Exception(f"Path does not exist: {classesRootPath}")
+
+        self.Log(self.LOG_DEVELOPMENT,
+                 f'Looking for python files in "{classesRootPath}"...')
+
+        python_files = classesRootPath.rglob("*.py")
+
+        # Check if a py files are in a folder with the same name !!! (same without extension)
+        filepaths = [f for f in python_files if f.stem == f.parent.stem]
+
+        if not filepaths:
+            raise FileNotFoundError(
+                f"No module files found in {classesRootPath}")
+
+        self.Log(self.LOG_DEVELOPMENT,
+                 f"Found {str(len(filepaths))} modules files")
+
+        return filepaths
+
+    def GetClassFromName(self, wantedName: str) -> type | None:
+        """Get the class of given name, and load it
+
+        Args:
+            wantedName (str): The name to look for
+
+        Returns:
+            type | None: The class if found, None if not found
+        """
+
+        # Check from already loaded classes:
+        module_class = next(
+            (m for m in self.loadedClasses if m.__name__ == wantedName), None)
+
+        if module_class:
+            return module_class
+
+        modulePath = next(
+            (m for m in self.moduleFilePaths if m.stem == wantedName), None)
+
+        if modulePath:
+
+            loadedModule = self.LoadModule(modulePath)
+            loadedClass = self.GetClassFromModule(loadedModule)
+            self.loadedClasses.append(loadedClass)
+            return loadedClass
+
         else:
-            self.mainPath = path.dirname(path.abspath(module_path))
-        # THIS MUST BE IMPLEMENTED IN SUBCLASSES, IS THE CLASS I WANT TO SEARCH !!!!
-        self.baseClass = None
+            return None
 
-    def GetClassFromName(self, wantedName) -> type | None:
-        # From name, load the correct module and extract the class
-        for module in self.modulesFilename:  # Search the module file
-            moduleName = self.ModuleNameFromPath(module)
-            # Check if the module name matches the given name
-            if wantedName == moduleName:
-                # Load the module
-                loadedModule = self.LoadModule(module)
-                # Now get the class
-                return self.GetClassFromModule(loadedModule)
-        return None
-
-    def LoadModule(self, path):  # Get module and load it from the path
+    def LoadModule(self, module_path: Path):  # Get module and load it from the path
         try:
             loader = importlib.machinery.SourceFileLoader(
-                self.ModuleNameFromPath(path), path)
+                module_path.stem, str(module_path))
             spec = importlib.util.spec_from_loader(loader.name, loader)
 
             if not spec:
@@ -58,50 +106,25 @@ class ClassManager(LogObject):
 
             module = importlib.util.module_from_spec(spec)
             loader.exec_module(module)
-            moduleName = os.path.split(path)[1][:-3]
-            sys.modules[moduleName] = module
+            sys.modules[module_path.stem] = module
             return module
         except Exception as e:
-            self.Log(self.LOG_ERROR, "Error while loading module " +
-                     path + ": " + str(e))
+            self.Log(self.LOG_ERROR,
+                     f"Error while loading module {module_path.stem}: {str(e)}")
 
     # From the module passed, I search for a Class that has className=moduleName
     def GetClassFromModule(self, module):
         for name, obj in inspect.getmembers(module):
             if inspect.isclass(obj):
-                if(name == module.__name__):
+                if (name == module.__name__):
                     return obj
         raise Exception(f"No class found: {module.__name__}")
 
-    # List files in the _path directory and get only files in subfolders
-    def GetModulesFilename(self, _path):
-        classesRootPath = path.join(self.mainPath, _path)
-        if os.path.exists(classesRootPath):
-            self.Log(self.LOG_DEVELOPMENT,
-                     "Looking for python files in \"" + _path + os.sep + "\"...")
-            result = list(Path(classesRootPath).rglob("*.py"))
-            entities = []
-            for file in result:
-                filename = str(file)
-                # TO check if a py files is in a folder !!!! with the same name !!! (same without extension)
-                pathList = filename.split(os.sep)
-                if len(pathList) >= 2:
-                    if pathList[len(pathList)-1][:-3] == pathList[len(pathList)-2]:
-                        entities.append(filename)
-
-            self.modulesFilename = self.modulesFilename + entities
-            self.Log(self.LOG_DEVELOPMENT, "Found " +
-                     str(len(entities)) + " modules files")
-
-    def ModuleNameFromPath(self, path):
-        classname = os.path.split(path)
-        return classname[1][:-3]
-
-    def ListAvailableClassesNames(self) -> list:
-        res = []
-        for py in self.modulesFilename:
-            res.append(path.basename(py).split(".py")[0])
-        return res
-
     def ListAvailableClasses(self) -> list:
-        return [self.GetClassFromName(n) for n in self.ListAvailableClassesNames()]
+        """Get all classes of this ClassManager
+
+        Returns:
+            list: The list of classes
+        """
+
+        return [self.GetClassFromName(f.stem) for f in self.moduleFilePaths]

--- a/IoTuring/ClassManager/ClassManager.py
+++ b/IoTuring/ClassManager/ClassManager.py
@@ -6,6 +6,7 @@ import sys
 import inspect
 from pathlib import Path
 
+from IoTuring.ClassManager.consts import *
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.MyApp.App import App
 
@@ -17,10 +18,12 @@ class ClassManager(LogObject):
     The important this is that the class is inside a folder that exactly the same name of the Class and of the file (obviously not talking about extensions)
     """
 
-    # Set up these class variables in subclasses:
-    classesRelativePath = None  # Change in subclasses!
+    def __init__(self, class_key:str) -> None:
 
-    def __init__(self) -> None:
+        if class_key not in CLASS_PATH:
+            raise Exception(f"Invalid class key {class_key}")
+        else:
+            self.classesRelativePath = CLASS_PATH[class_key]
 
         # Store loaded classes here:
         self.loadedClasses = []

--- a/IoTuring/ClassManager/EntityClassManager.py
+++ b/IoTuring/ClassManager/EntityClassManager.py
@@ -1,8 +1,0 @@
-from IoTuring.ClassManager.ClassManager import ClassManager
-from IoTuring.ClassManager import consts
-
-
-class EntityClassManager(ClassManager):
-    """Class to load Entities from the Entitties dir"""
-
-    classesRelativePath = consts.ENTITIES_PATH

--- a/IoTuring/ClassManager/EntityClassManager.py
+++ b/IoTuring/ClassManager/EntityClassManager.py
@@ -1,12 +1,8 @@
 from IoTuring.ClassManager.ClassManager import ClassManager
 from IoTuring.ClassManager import consts
-from IoTuring.Entity.Entity import Entity
 
 
-# Class to load Entities from the Entitties dir and get them from name
 class EntityClassManager(ClassManager):
-    def __init__(self):
-        ClassManager.__init__(self)
-        self.baseClass = Entity
-        self.GetModulesFilename(consts.ENTITIES_PATH)
-        # self.GetModulesFilename(consts.CUSTOM_ENTITIES_PATH) # TODO Decide if I'll use customs
+    """Class to load Entities from the Entitties dir"""
+
+    classesRelativePath = consts.ENTITIES_PATH

--- a/IoTuring/ClassManager/WarehouseClassManager.py
+++ b/IoTuring/ClassManager/WarehouseClassManager.py
@@ -1,8 +1,0 @@
-from IoTuring.ClassManager.ClassManager import ClassManager
-from IoTuring.ClassManager import consts
-
-
-class WarehouseClassManager(ClassManager):
-    """Class to load Warehouses from the Warehouses dir"""
-
-    classesRelativePath = consts.WAREHOUSES_PATH

--- a/IoTuring/ClassManager/WarehouseClassManager.py
+++ b/IoTuring/ClassManager/WarehouseClassManager.py
@@ -1,11 +1,8 @@
 from IoTuring.ClassManager.ClassManager import ClassManager
 from IoTuring.ClassManager import consts
-from IoTuring.Warehouse.Warehouse import Warehouse
 
 
-# Class to load Entities from the Entitties dir and get them from name
 class WarehouseClassManager(ClassManager):
-    def __init__(self):
-        ClassManager.__init__(self)
-        self.baseClass = Warehouse
-        self.GetModulesFilename(consts.WAREHOUSES_PATH)
+    """Class to load Warehouses from the Warehouses dir"""
+
+    classesRelativePath = consts.WAREHOUSES_PATH

--- a/IoTuring/ClassManager/consts.py
+++ b/IoTuring/ClassManager/consts.py
@@ -1,2 +1,7 @@
-ENTITIES_PATH = "Entity/Deployments"
-WAREHOUSES_PATH = "Warehouse/Deployments"
+KEY_ENTITY = "entity"
+KEY_WAREHOUSE = "warehouse"
+
+CLASS_PATH = {
+    KEY_ENTITY: "Entity/Deployments",
+    KEY_WAREHOUSE: "Warehouse/Deployments"
+}

--- a/IoTuring/ClassManager/consts.py
+++ b/IoTuring/ClassManager/consts.py
@@ -1,2 +1,2 @@
-ENTITIES_PATH = "../Entity/Deployments/"
-WAREHOUSES_PATH = "../Warehouse/Deployments/"
+ENTITIES_PATH = "Entity/Deployments"
+WAREHOUSES_PATH = "Warehouse/Deployments"

--- a/IoTuring/Configurator/ConfiguratorLoader.py
+++ b/IoTuring/Configurator/ConfiguratorLoader.py
@@ -4,8 +4,7 @@ import sys
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Configurator.Configurator import KEY_ENTITY_TYPE, Configurator, KEY_ACTIVE_ENTITIES, KEY_ACTIVE_WAREHOUSES, KEY_WAREHOUSE_TYPE
-from IoTuring.ClassManager.WarehouseClassManager import WarehouseClassManager
-from IoTuring.ClassManager.EntityClassManager import EntityClassManager
+from IoTuring.ClassManager.ClassManager import ClassManager, KEY_ENTITY, KEY_WAREHOUSE
 from IoTuring.Warehouse.Warehouse import Warehouse
 
 
@@ -18,7 +17,7 @@ class ConfiguratorLoader(LogObject):
     # Return list of instances initialized using their configurations
     def LoadWarehouses(self) -> list[Warehouse]:
         warehouses = []
-        wcm = WarehouseClassManager()
+        wcm = ClassManager(KEY_WAREHOUSE)
         if not KEY_ACTIVE_WAREHOUSES in self.configurations:
             self.Log(
                 self.LOG_ERROR, "You have to enable at least one warehouse: configure it using -c argument")
@@ -41,7 +40,7 @@ class ConfiguratorLoader(LogObject):
     # Return list of entities initialized
     def LoadEntities(self) -> list[Entity]:
         entities = []
-        ecm = EntityClassManager()
+        ecm = ClassManager(KEY_ENTITY)
         if not KEY_ACTIVE_ENTITIES in self.configurations:
             self.Log(
                 self.LOG_ERROR, "You have to enable at least one entity: configure it using -c argument")

--- a/IoTuring/MyApp/App.py
+++ b/IoTuring/MyApp/App.py
@@ -1,4 +1,5 @@
 from importlib.metadata import metadata
+from pathlib import Path
 
 class App():
     METADATA = metadata('IoTuring')
@@ -39,6 +40,15 @@ class App():
     @staticmethod
     def getUrlReleases() -> str:
         return App.URL_RELEASES
+
+    @staticmethod
+    def getRootPath() -> Path:
+        """Get the project root path
+
+        Returns:
+            Path: The path to th project root as a pathlib.Path
+        """
+        return Path(__file__).parents[1]
 
     def __str__(self) -> str:
         msg = ""

--- a/tests/ClassManager/test_ClassManager.py
+++ b/tests/ClassManager/test_ClassManager.py
@@ -1,0 +1,22 @@
+from IoTuring.ClassManager.EntityClassManager import EntityClassManager
+from IoTuring.ClassManager.WarehouseClassManager import WarehouseClassManager
+
+
+class TestEntityClassManager:
+    def testClassCount(self):
+        ecm = EntityClassManager()
+        assert bool(ecm.loadedClasses) == False
+        
+        class_num = len(ecm.ListAvailableClasses())
+        assert class_num == len(ecm.GetModuleFilePaths())
+        assert class_num == len(ecm.loadedClasses)
+
+
+class TestWarehouseClassManager:
+    def testClassCount(self):
+        wcm = WarehouseClassManager()
+        assert bool(wcm.loadedClasses) == False
+        
+        class_num = len(wcm.ListAvailableClasses())
+        assert class_num == len(wcm.GetModuleFilePaths())
+        assert class_num == len(wcm.loadedClasses)

--- a/tests/ClassManager/test_ClassManager.py
+++ b/tests/ClassManager/test_ClassManager.py
@@ -1,22 +1,13 @@
-from IoTuring.ClassManager.EntityClassManager import EntityClassManager
-from IoTuring.ClassManager.WarehouseClassManager import WarehouseClassManager
+from IoTuring.ClassManager.ClassManager import ClassManager, KEY_ENTITY, KEY_WAREHOUSE
 
 
-class TestEntityClassManager:
+class TestClassManager:
     def testClassCount(self):
-        ecm = EntityClassManager()
-        assert bool(ecm.loadedClasses) == False
-        
-        class_num = len(ecm.ListAvailableClasses())
-        assert class_num == len(ecm.GetModuleFilePaths())
-        assert class_num == len(ecm.loadedClasses)
+        for class_key in [KEY_ENTITY, KEY_WAREHOUSE]:
 
+            cm = ClassManager(class_key)
+            assert bool(cm.loadedClasses) == False
 
-class TestWarehouseClassManager:
-    def testClassCount(self):
-        wcm = WarehouseClassManager()
-        assert bool(wcm.loadedClasses) == False
-        
-        class_num = len(wcm.ListAvailableClasses())
-        assert class_num == len(wcm.GetModuleFilePaths())
-        assert class_num == len(wcm.loadedClasses)
+            class_num = len(cm.ListAvailableClasses())
+            assert class_num == len(cm.GetModuleFilePaths())
+            assert class_num == len(cm.loadedClasses)


### PR DESCRIPTION
- Part 2 of #90 separation
- Rewrite ClassManager:
  - Use [pathlib](https://docs.python.org/3/library/pathlib.html). It makes a lot of file and directory commands much simpler, nicer and more readable.
  - ClassManager functionality didn't change, merged functions which were called only once, removed unused code.
- New method: `MyApp.App.getRootPath()`: Returns the absolute filepath of the installation. It can be useful at other situations in the future.

Question to @richibrics:

The 2 subclasses of ClassManager became really short. Maybe they could be replaced by something like this:
`EntityClassManager()` = `ClassManager(KEY_ENTITIES)` 
`WarehouseClassManager()` = `ClassManager(KEY_WAREHOUSES)` 

Because these subclasses are differ only by the base path, and I don't really see how they can change in the future. 

What do you think of this?