### PR TITLE
Edit configuration in menu

### DIFF
--- a/IoTuring/Configurator/Configuration.py
+++ b/IoTuring/Configurator/Configuration.py
@@ -29,10 +29,11 @@ class SingleConfiguration:
         """
         self.config_class = config_class
         self.config_type = config_dict.pop(CONFIG_KEY_TYPE)
+        print(self.GetLongName())
         self.configurations = config_dict
 
     def GetType(self) -> str:
-        """Get the type name of entity"""
+        """Get the type name of entity or warehouse (e.g. Cpu, Battery, HomeAssistant)"""
         return self.config_type
 
     def GetTag(self) -> str:
@@ -53,7 +54,9 @@ class SingleConfiguration:
         return label
 
     def GetLongName(self) -> str:
-        """Add category name to the end """
+        """ Get the type with the category name at the end (e.g. CpuEntity, HomeAssistantWarehouse)"""
+        
+        # Add category name to the end 
         return str(self.GetType() + self.GetClassKey().capitalize())
 
     def GetClassKey(self) -> str:
@@ -98,7 +101,7 @@ class SingleConfiguration:
         return bool(config_key in self.configurations)
 
     def ToDict(self, include_type: bool = True) -> dict:
-        """Full configuration as a dict, as it would be saved to a file """
+        """ SingleConfiguration as a dict, as it would be saved to a file """
         full_dict = self.configurations
         if include_type:
             full_dict[CONFIG_KEY_TYPE] = self.GetType()
@@ -136,7 +139,9 @@ class FullConfiguration:
         return [config for config in self.configs if config.config_class == CONFIG_CLASS[class_key]]
 
     def GetConfigsOfType(self, config_type: str) -> list[SingleConfiguration]:
-        """Return all configs with the given type
+        """Return all configs with the given type.
+
+        For example all configurations of Notify entity.
 
         Args:
             config_type (str): The type of config to return

--- a/IoTuring/Configurator/Configuration.py
+++ b/IoTuring/Configurator/Configuration.py
@@ -29,7 +29,6 @@ class SingleConfiguration:
         """
         self.config_class = config_class
         self.config_type = config_dict.pop(CONFIG_KEY_TYPE)
-        print(self.GetLongName())
         self.configurations = config_dict
 
     def GetType(self) -> str:

--- a/IoTuring/Configurator/Configuration.py
+++ b/IoTuring/Configurator/Configuration.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from IoTuring.ClassManager.consts import KEY_ENTITY, KEY_WAREHOUSE
+
+CONFIG_CLASS = {
+    KEY_ENTITY: "active_entities",
+    KEY_WAREHOUSE: "active_warehouses"
+}
+
+BLANK_CONFIGURATION = {
+    CONFIG_CLASS[KEY_ENTITY]: [{"type": "AppInfo"}],
+    CONFIG_CLASS[KEY_WAREHOUSE]: []
+}
+
+
+CONFIG_KEY_TAG = "tag"
+CONFIG_KEY_TYPE = "type"
+
+
+class SingleConfiguration:
+    """Single configuration of an entity or warehouse"""
+
+    def __init__(self, config_class: str, config_dict: dict) -> None:
+        """Create a new SingleConfiguration
+
+        Args:
+            config_class (str): CONFIG_CLASS of the config
+            config_dict (dict): All options as in config file
+        """
+        self.config_class = config_class
+        self.config_type = config_dict.pop(CONFIG_KEY_TYPE)
+        self.configurations = config_dict
+
+    def GetType(self) -> str:
+        """Get the type name of entity"""
+        return self.config_type
+
+    def GetTag(self) -> str:
+        """Get the tag of entity"""
+        if CONFIG_KEY_TAG in self.configurations:
+            return self.configurations[CONFIG_KEY_TAG]
+        else:
+            return ""
+
+    def GetLabel(self) -> str:
+        """Get the type name of this configuration, add tag if multi"""
+
+        label = self.GetType()
+
+        if self.GetTag():
+            label += f" with tag {self.GetTag()}"
+
+        return label
+
+    def GetLongName(self) -> str:
+        """Add category name to the end """
+        return str(self.GetType() + self.GetClassKey().capitalize())
+
+    def GetClassKey(self) -> str:
+        """Get the CLASS_KEY of this configuration, e.g. KEY_ENTITY, KEY_WAREHOUSE"""
+        return [i for i in CONFIG_CLASS if CONFIG_CLASS[i] == self.config_class][0]
+
+    def GetConfigValue(self, config_key: str):
+        """Get the value of a config key
+
+        Args:
+            config_key (str): The key of the configuration
+
+        Raises:
+            ValueError: If the key is not found
+
+        Returns:
+            The value of the key.
+        """
+        if config_key in self.configurations:
+            return self.configurations[config_key]
+        else:
+            raise ValueError("Config key not set")
+
+    def UpdateConfigValue(self, config_key: str, config_value: str) -> None:
+        """Update the value of the configuration. Overwrites existing value
+
+        Args:
+            config_key (str): The key of the configuration
+            config_value (str): The preferred value
+        """
+        self.configurations[config_key] = config_value
+
+    def HasConfigKey(self, config_key: str) -> bool:
+        """Check if key has a value
+
+        Args:
+            config_key (str): The key of the configuration
+
+        Returns:
+            bool: If it has a value
+        """
+        return bool(config_key in self.configurations)
+
+    def ToDict(self, include_type: bool = True) -> dict:
+        """Full configuration as a dict, as it would be saved to a file """
+        full_dict = self.configurations
+        if include_type:
+            full_dict[CONFIG_KEY_TYPE] = self.GetType()
+        return full_dict
+
+
+class FullConfiguration:
+    """Full configuration of all classes"""
+
+    def __init__(self, config_dict: dict | None) -> None:
+        """Initialize from dict or create blank
+
+        Args:
+            config_dict (dict | None): The config as dict or None to create blank
+        """
+
+        config_dict = config_dict or BLANK_CONFIGURATION
+        self.configs = []
+
+        for config_class, single_configs in config_dict.items():
+            for single_config_dict in single_configs:
+
+                self.configs.append(SingleConfiguration(
+                    config_class, single_config_dict))
+
+    def GetConfigsOfClass(self, class_key: str) -> list[SingleConfiguration]:
+        """Return all configurations of class
+
+        Args:
+            class_key (str): CLASS_KEY of the class: e.g. KEY_ENTITY, KEY_WAREHOUSE
+
+        Returns:
+            list: Configurations in the class. Empty list if none found.
+        """
+        return [config for config in self.configs if config.config_class == CONFIG_CLASS[class_key]]
+
+    def GetConfigsOfType(self, config_type: str) -> list[SingleConfiguration]:
+        """Return all configs with the given type
+
+        Args:
+            config_type (str): The type of config to return
+
+        Returns:
+            list: Configurations of the given type. Empty list if none found.
+        """
+
+        return [config for config in self.configs if config.GetType() == config_type]
+
+    def RemoveActiveConfiguration(self, config: SingleConfiguration) -> None:
+        """Remove a configuration from the list of active configurations"""
+        if config in self.configs:
+            self.configs.remove(config)
+        else:
+            raise ValueError("Configuration not found")
+
+    def AddConfiguration(self, class_key: str, config_type: str, single_config_dict: dict) -> None:
+        """Add a new configuration to the list of active configurations
+
+        Args:
+            class_key (str): CLASS_KEY of the class: e.g. KEY_ENTITY, KEY_WAREHOUSE
+            config_type (str): The type of the configuration
+            single_config_dict (dict): all settings as a dict
+        """
+
+        config_class = CONFIG_CLASS[class_key]
+        single_config_dict[CONFIG_KEY_TYPE] = config_type
+
+        self.configs.append(SingleConfiguration(
+            config_class, single_config_dict))
+
+    def ToDict(self) -> dict:
+        """Full configuration as a dict, for saving to file """
+        config_dict = {}
+        for class_key in CONFIG_CLASS:
+
+            config_dict[CONFIG_CLASS[class_key]] = []
+
+            for single_config in self.GetConfigsOfClass(class_key):
+                config_dict[CONFIG_CLASS[class_key]].append(
+                    single_config.ToDict())
+
+        return config_dict

--- a/IoTuring/Configurator/Configurator.py
+++ b/IoTuring/Configurator/Configurator.py
@@ -334,22 +334,24 @@ class Configurator(LogObject):
                 preset.AddTagQuestion()
 
             for entry in preset.presets:
-                # Load config instead of default:
-                if single_config.HasConfigKey(entry.key):
-                    value = single_config.GetConfigValue(entry.key)
-                    if entry.question_type == "secret":
-                        value = "*" * len(value)
-                else:
-                    value = entry.default
+                if entry.ShouldDisplay(single_config.ToDict(include_type=False)):
 
-                # Nice display for None:
-                if value is None:
-                    value = ""
+                    # Load config instead of default:
+                    if single_config.HasConfigKey(entry.key):
+                        value = single_config.GetConfigValue(entry.key)
+                        if entry.question_type == "secret":
+                            value = "*" * len(value)
+                    else:
+                        value = entry.default
 
-                choices.append({
-                    "name": f"{entry.name}: {value}",
-                    "value": entry.key
-                })
+                    # Nice display for None:
+                    if value is None:
+                        value = ""
+
+                    choices.append({
+                        "name": f"{entry.name}: {value}",
+                        "value": entry.key
+                    })
 
             choice = self.DisplayMenu(
                 choices=choices,

--- a/IoTuring/Configurator/MenuPreset.py
+++ b/IoTuring/Configurator/MenuPreset.py
@@ -37,8 +37,15 @@ class QuestionPreset():
         if self.mandatory:
             self.question += " {!}"
 
-    def ShouldDisplay(self, menupreset: "MenuPreset") -> bool:
-        """Check if this question should be displayed"""
+    def ShouldDisplay(self, answer_dict: dict) -> bool:
+        """Check if this question should be displayed
+
+        Args:
+            answer_dict (dict): A dict of previous answers
+
+        Returns:
+            bool: If this question should be displayed
+        """
 
         should_display = True
 
@@ -46,19 +53,16 @@ class QuestionPreset():
         if self.dependsOn:
             dependencies_ok = []
             for key, value in self.dependsOn.items():
-                answered = menupreset.GetAnsweredPresetByKey(key)
                 dependency_ok = False
-
-                # Found the key in results:
-                if answered:
+                if key in answer_dict:
 
                     # Value is True or False:
                     if isinstance(value, bool):
-                        if answered.value:
+                        if answer_dict[key]:
                             dependency_ok = True
 
                     # Value must match:
-                    elif isinstance(value, str) and answered.value == value:
+                    elif isinstance(value, str) and answer_dict[key] == value:
                         dependency_ok = True
 
                 dependencies_ok.append(dependency_ok)
@@ -212,7 +216,7 @@ class MenuPreset():
             try:
 
                 # It should be displayed, ask question:
-                if q_preset.ShouldDisplay(self):
+                if q_preset.ShouldDisplay(self.GetDict()):
 
                     value = q_preset.Ask()
 
@@ -225,9 +229,6 @@ class MenuPreset():
                 raise UserCancelledException
             except Exception as e:
                 print(f"Error while making question for {q_preset.name}:", e)
-
-    def GetAnsweredPresetByKey(self, key: str) -> QuestionPreset | None:
-        return next((entry for entry in self.results if entry.key == key), None)
 
     def GetPresetByKey(self, key: str) -> QuestionPreset | None:
         """Get the QuestionPreset of this key. Returns None if not found"""

--- a/IoTuring/Configurator/MenuPreset.py
+++ b/IoTuring/Configurator/MenuPreset.py
@@ -28,7 +28,13 @@ class QuestionPreset():
         self.value = None
 
         self.question = self.name
-        if mandatory:
+
+        # yesno question cannot be mandatory:
+        if self.question_type == "yesno":
+            self.mandatory = False
+
+        # Add mandatory mark:
+        if self.mandatory:
             self.question += " {!}"
 
     def ShouldDisplay(self, menupreset: "MenuPreset") -> bool:
@@ -62,6 +68,82 @@ class QuestionPreset():
                 should_display = False
 
         return should_display
+
+    def Ask(self):
+        """Ask a single question preset"""
+
+        question_options = {}
+
+        if self.mandatory:
+            def validate(x): return bool(x)
+            question_options.update({
+                "validate": validate,
+                "invalid_message": "You must provide a value for this key"
+            })
+
+        question_options["message"] = self.question + ":"
+
+        if self.default is not None:
+            # yesno questions need boolean default:
+            if self.question_type == "yesno":
+                question_options["default"] = \
+                    bool(str(self.default).lower()
+                         in BooleanAnswers.TRUE_ANSWERS)
+            elif self.question_type == "integer":
+                question_options["default"] = int(self.default)
+            else:
+                question_options["default"] = self.default
+        else:
+            if self.question_type == "integer":
+                # The default integer is 0, overwrite to None:
+                question_options["default"] = None
+
+        # text:
+        prompt_function = inquirer.text
+
+        if self.question_type == "secret":
+            prompt_function = inquirer.secret
+
+        elif self.question_type == "yesno":
+            prompt_function = inquirer.confirm
+            question_options.update({
+                "filter": lambda x: "Y" if x else "N"
+            })
+
+        elif self.question_type == "select":
+            prompt_function = inquirer.select
+            question_options.update({
+                "choices": self.choices
+            })
+
+        elif self.question_type == "integer":
+            prompt_function = inquirer.number
+            question_options["float_allowed"] = False
+
+        elif self.question_type == "filepath":
+            prompt_function = inquirer.filepath
+
+        # Ask the question:
+        prompt = prompt_function(
+            instruction=self.instruction,
+            **question_options
+        )
+
+        self.cancelled = False
+
+        @prompt.register_kb("escape")
+        def _handle_esc(event):
+            prompt._mandatory = False
+            prompt._handle_skip(event)
+            # exception raised here catched by inquirer.
+            self.cancelled = True
+
+        value = prompt.execute()
+
+        if self.cancelled:
+            raise UserCancelledException
+
+        return value
 
 
 class MenuPreset():
@@ -132,75 +214,7 @@ class MenuPreset():
                 # It should be displayed, ask question:
                 if q_preset.ShouldDisplay(self):
 
-                    question_options = {}
-
-                    if q_preset.mandatory:
-                        def validate(x): return bool(x)
-                        question_options.update({
-                            "validate": validate,
-                            "invalid_message": "You must provide a value for this key"
-                        })
-
-                    question_options["message"] = q_preset.question + ":"
-
-                    if q_preset.default is not None:
-                        # yesno questions need boolean default:
-                        if q_preset.question_type == "yesno":
-                            question_options["default"] = \
-                                bool(str(q_preset.default).lower()
-                                     in BooleanAnswers.TRUE_ANSWERS)
-                        elif q_preset.question_type == "integer":
-                            question_options["default"] = int(q_preset.default)
-                        else:
-                            question_options["default"] = q_preset.default
-                    else:
-                        if q_preset.question_type == "integer":
-                            # The default default is 0, overwrite to None:
-                            question_options["default"] = None
-
-                    # text:
-                    prompt_function = inquirer.text
-
-                    if q_preset.question_type == "secret":
-                        prompt_function = inquirer.secret
-
-                    elif q_preset.question_type == "yesno":
-                        prompt_function = inquirer.confirm
-                        question_options.update({
-                            "filter": lambda x: "Y" if x else "N"
-                        })
-
-                    elif q_preset.question_type == "select":
-                        prompt_function = inquirer.select
-                        question_options.update({
-                            "choices": q_preset.choices
-                        })
-
-                    elif q_preset.question_type == "integer":
-                        prompt_function = inquirer.number
-                        question_options["float_allowed"] = False
-
-                    elif q_preset.question_type == "filepath":
-                        prompt_function = inquirer.filepath
-
-                    # Create the prompt:
-                    prompt = prompt_function(
-                        instruction=q_preset.instruction,
-                        **question_options
-                    )
-
-                    # Handle escape keypress:
-                    @prompt.register_kb("escape")
-                    def _handle_esc(event):
-                        prompt._mandatory = False
-                        prompt._handle_skip(event)
-                        # exception raised here catched by inquirer.
-                        self.cancelled = True
-
-                    value = prompt.execute()
-
-                    if self.cancelled:
-                        raise UserCancelledException
+                    value = q_preset.Ask()
 
                     if value:
                         q_preset.value = value
@@ -214,6 +228,10 @@ class MenuPreset():
 
     def GetAnsweredPresetByKey(self, key: str) -> QuestionPreset | None:
         return next((entry for entry in self.results if entry.key == key), None)
+
+    def GetPresetByKey(self, key: str) -> QuestionPreset | None:
+        """Get the QuestionPreset of this key. Returns None if not found"""
+        return next((entry for entry in self.presets if entry.key == key), None)
 
     def GetDict(self) -> dict:
         """ Get a dict with keys and responses"""

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -3,27 +3,25 @@ import time
 import subprocess
 
 from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
+from IoTuring.Configurator.Configuration import SingleConfiguration
 from IoTuring.Exceptions.Exceptions import UnknownEntityKeyException
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Entity.EntityData import EntityData, EntitySensor, EntityCommand, ExtraAttribute
 from IoTuring.MyApp.SystemConsts import OperatingSystemDetection as OsD
 
-KEY_ENTITY_TAG = 'tag'  # from Configurator.Configurator
-
 DEFAULT_UPDATE_TIMEOUT = 10
 
 
-class Entity(LogObject, ConfiguratorObject):
-    NAME = "Unnamed"
-    ALLOW_MULTI_INSTANCE = False
+class Entity(ConfiguratorObject, LogObject):
 
-    def __init__(self, configurations) -> None:
+    def __init__(self, single_configuration: SingleConfiguration) -> None:
+        super().__init__(single_configuration)
+
         # Prepare the entity
         self.entitySensors = []
         self.entityCommands = []
 
-        self.configurations = configurations
-        self.SetTagFromConfiguration()
+        self.tag = self.GetConfigurations().GetTag()
 
         # When I update the values this number changes (randomly) so each warehouse knows I have updated
         self.valuesID = 0
@@ -145,7 +143,7 @@ class Entity(LogObject, ConfiguratorObject):
 
     def GetEntityTag(self) -> str:
         """ Return entity identifier tag """
-        return self.tag  # Set from SetTagFromConfiguration on entity init
+        return self.tag
 
     def GetEntityNameWithTag(self) -> str:
         """ Return entity name and tag combined (or name alone if no tag is present) """
@@ -162,13 +160,6 @@ class Entity(LogObject, ConfiguratorObject):
 
     def LogSource(self):
         return self.GetEntityId()
-
-    def SetTagFromConfiguration(self):
-        """ Set tag from configuration or set it blank if not present there """
-        if self.GetConfigurations() is not None and KEY_ENTITY_TAG in self.GetConfigurations():
-            self.tag = self.GetFromConfigurations(KEY_ENTITY_TAG)
-        else:
-            self.tag = ""
 
     def RunCommand(self,
                    command: str | list,
@@ -225,12 +216,6 @@ class Entity(LogObject, ConfiguratorObject):
             raise Exception(f"Error during {command_name} command: {str(e)}")
 
         return p
-
-    @classmethod
-    def AllowMultiInstance(cls):
-        """ Return True if this Entity can have multiple instances, useful for customizable entities 
-            These entities are the ones that must have a tag to be recognized """
-        return cls.ALLOW_MULTI_INSTANCE
 
     @classmethod
     def CheckSystemSupport(cls):

--- a/IoTuring/Warehouse/Warehouse.py
+++ b/IoTuring/Warehouse/Warehouse.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from IoTuring.Entity.Entity import Entity
 from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
+from IoTuring.Configurator.Configuration import SingleConfiguration
 from IoTuring.Entity.EntityManager import EntityManager
 
 from threading import Thread
@@ -10,12 +11,12 @@ import time
 DEFAULT_LOOP_TIMEOUT = 10
 
 
-class Warehouse(LogObject, ConfiguratorObject):
-    NAME = "Unnamed"
+class Warehouse(ConfiguratorObject, LogObject):
 
-    def __init__(self, configurations) -> None:
+    def __init__(self, single_configuration: SingleConfiguration) -> None:
+        super().__init__(single_configuration)
+
         self.loopTimeout = DEFAULT_LOOP_TIMEOUT
-        self.configurations = configurations
 
     def Start(self) -> None:
         """ Initial configuration and start the thread that will loop the Warehouse.Loop() function"""
@@ -35,7 +36,7 @@ class Warehouse(LogObject, ConfiguratorObject):
     def LoopThread(self) -> None:
         """ Entry point of the warehouse thread, will run Loop() periodically """
         self.Loop()  # First call without sleep before
-        while(True):
+        while (True):
             if self.ShouldCallLoop():
                 self.Loop()
 
@@ -56,4 +57,3 @@ class Warehouse(LogObject, ConfiguratorObject):
 
     def LogSource(self):
         return self.GetWarehouseId()
-


### PR DESCRIPTION
- Part 3 of #90 separation
- Now it's possible to edit existing configurations in the config menu
- `Configuration.py`: New classes to store the config, so it's not a simple dict anymore
- `Configurator.py`: Duplicate WH/entity methods merged
- All other changes related to these

It should work now, please report if something is not working as expected.

TODO:
- [x] Fix terminal entity editing, `display_if_key_value` not supported yet