### PR TITLE
AppSettings, set update interval

### DIFF
--- a/IoTuring/ClassManager/consts.py
+++ b/IoTuring/ClassManager/consts.py
@@ -1,7 +1,10 @@
+# Class keys:
 KEY_ENTITY = "entity"
 KEY_WAREHOUSE = "warehouse"
+KEY_SETTINGS = "settings"
 
 CLASS_PATH = {
     KEY_ENTITY: "Entity/Deployments",
-    KEY_WAREHOUSE: "Warehouse/Deployments"
+    KEY_WAREHOUSE: "Warehouse/Deployments",
+    KEY_SETTINGS: "Settings/Deployments"
 }

--- a/IoTuring/Configurator/Configuration.py
+++ b/IoTuring/Configurator/Configuration.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from IoTuring.ClassManager.consts import KEY_ENTITY, KEY_WAREHOUSE
+from IoTuring.ClassManager.consts import KEY_ENTITY, KEY_WAREHOUSE, KEY_SETTINGS
 
 CONFIG_CLASS = {
     KEY_ENTITY: "active_entities",
-    KEY_WAREHOUSE: "active_warehouses"
+    KEY_WAREHOUSE: "active_warehouses",
+    KEY_SETTINGS: "settings"
 }
 
 BLANK_CONFIGURATION = {
-    CONFIG_CLASS[KEY_ENTITY]: [{"type": "AppInfo"}],
-    CONFIG_CLASS[KEY_WAREHOUSE]: []
+    CONFIG_CLASS[KEY_ENTITY]: [{"type": "AppInfo"}]
 }
 
 

--- a/IoTuring/Configurator/ConfiguratorObject.py
+++ b/IoTuring/Configurator/ConfiguratorObject.py
@@ -1,5 +1,5 @@
 from IoTuring.Configurator.MenuPreset import BooleanAnswers, MenuPreset
-from IoTuring.Configurator.Configuration import SingleConfiguration, CONFIG_CLASS
+from IoTuring.Configurator.Configuration import SingleConfiguration, CONFIG_CLASS, CONFIG_KEY_TYPE
 
 
 class ConfiguratorObject:
@@ -11,8 +11,7 @@ class ConfiguratorObject:
         self.configurations = single_configuration
 
         # Add missing default values:
-        preset = self.ConfigurationPreset()
-        defaults = preset.GetDefaults()
+        defaults = self.ConfigurationPreset().GetDefaults()
 
         if defaults:
             for default_key, default_value in defaults.items():
@@ -59,3 +58,13 @@ class ConfiguratorObject:
         if class_key not in CONFIG_CLASS:
             raise Exception(f"Invalid class {class_key}")
         return class_key
+
+    @classmethod
+    def GetDefaultConfigurations(cls) -> SingleConfiguration:
+        """Get the default configuration of this class"""
+
+        # Get default configs as dict:
+        config_dict = cls.ConfigurationPreset().GetDefaults()
+        config_dict[CONFIG_KEY_TYPE] = cls.NAME
+
+        return SingleConfiguration(cls.GetClassKey(), config_dict=config_dict)

--- a/IoTuring/Entity/Entity.py
+++ b/IoTuring/Entity/Entity.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from IoTuring.Configurator.Configuration import SingleConfiguration
+    from IoTuring.Entity.EntityData import EntityData, EntitySensor, EntityCommand, ExtraAttribute
+
+
 import time
 import subprocess
 
 from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
-from IoTuring.Configurator.Configuration import SingleConfiguration
-from IoTuring.Exceptions.Exceptions import UnknownEntityKeyException
 from IoTuring.Logger.LogObject import LogObject
-from IoTuring.Entity.EntityData import EntityData, EntitySensor, EntityCommand, ExtraAttribute
+from IoTuring.Exceptions.Exceptions import UnknownEntityKeyException
+
 from IoTuring.MyApp.SystemConsts import OperatingSystemDetection as OsD
 
-DEFAULT_UPDATE_TIMEOUT = 10
+from IoTuring.Settings.Deployments.AppSettings.AppSettings import AppSettings, CONFIG_KEY_UPDATE_INTERVAL
 
 
 class Entity(ConfiguratorObject, LogObject):
@@ -25,7 +30,9 @@ class Entity(ConfiguratorObject, LogObject):
 
         # When I update the values this number changes (randomly) so each warehouse knows I have updated
         self.valuesID = 0
-        self.updateTimeout = DEFAULT_UPDATE_TIMEOUT
+
+        self.updateTimeout = int(
+            AppSettings.GetFromSettingsConfigurations(CONFIG_KEY_UPDATE_INTERVAL))
 
     def Initialize(self):
         """ Must be implemented in sub-classes, may be useful here to use the configuration """

--- a/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
+++ b/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
@@ -8,7 +8,7 @@ CONFIG_KEY_RETRY_INTERVAL = "retry_interval"
 
 
 class AppSettings(Settings):
-    """Singleton for storing AppSettings, not related to a specifuc Entity or Warehouse """
+    """Class that stores AppSettings, not related to a specifuc Entity or Warehouse """
     NAME = "App"
 
     @classmethod

--- a/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
+++ b/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
@@ -3,6 +3,7 @@ from IoTuring.Settings.Settings import Settings
 
 
 CONFIG_KEY_UPDATE_INTERVAL = "update_interval"
+CONFIG_KEY_RETRY_INTERVAL = "retry_interval"
 # CONFIG_KEY_SLOW_INTERVAL = "slow_interval"
 
 
@@ -17,6 +18,12 @@ class AppSettings(Settings):
         preset.AddEntry(name="Main update interval in seconds",
                         key=CONFIG_KEY_UPDATE_INTERVAL, mandatory=True,
                         question_type="integer", default=10)
+
+        preset.AddEntry(name="Connection retry interval in seconds",
+                        instruction="If broker is not available retry after this amount of time passed",
+                        key=CONFIG_KEY_RETRY_INTERVAL, mandatory=True,
+                        question_type="integer", default=1)
+
 
         # preset.AddEntry(name="Secondary update interval in minutes",
         #                 key=CONFIG_KEY_SLOW_INTERVAL, mandatory=True,

--- a/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
+++ b/IoTuring/Settings/Deployments/AppSettings/AppSettings.py
@@ -1,0 +1,25 @@
+from IoTuring.Configurator.MenuPreset import MenuPreset
+from IoTuring.Settings.Settings import Settings
+
+
+CONFIG_KEY_UPDATE_INTERVAL = "update_interval"
+# CONFIG_KEY_SLOW_INTERVAL = "slow_interval"
+
+
+class AppSettings(Settings):
+    """Singleton for storing AppSettings, not related to a specifuc Entity or Warehouse """
+    NAME = "App"
+
+    @classmethod
+    def ConfigurationPreset(cls):
+        preset = MenuPreset()
+
+        preset.AddEntry(name="Main update interval in seconds",
+                        key=CONFIG_KEY_UPDATE_INTERVAL, mandatory=True,
+                        question_type="integer", default=10)
+
+        # preset.AddEntry(name="Secondary update interval in minutes",
+        #                 key=CONFIG_KEY_SLOW_INTERVAL, mandatory=True,
+        #                 question_type="integer", default=10)
+
+        return preset

--- a/IoTuring/Settings/Settings.py
+++ b/IoTuring/Settings/Settings.py
@@ -1,0 +1,45 @@
+from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
+from IoTuring.Settings.SettingsManager import SettingsManager
+from IoTuring.Configurator.MenuPreset import BooleanAnswers
+
+
+class Settings(ConfiguratorObject):
+    """Base class for settings"""
+    NAME = "Settings"
+
+    @classmethod
+    def GetFromSettingsConfigurations(cls, key: str):
+        """Get value from settings' saved configurations from SettingsManager
+
+        Args:
+            key (str): The CONFIG_KEY of the configuration
+
+        Raises:
+            Exception: If the key not found
+
+        Returns:
+            Any: The config value
+        """
+
+        sM = SettingsManager()
+        saved_config = sM.GetConfigOfType(cls)
+
+        if saved_config.HasConfigKey(key):
+            return saved_config.GetConfigValue(key)
+        else:
+            raise Exception(
+                f"Can't find key {key} in SettingsManager configurations")
+
+    @classmethod
+    def GetTrueOrFalseFromSettingsConfigurations(cls, key: str) -> bool:
+        """Get boolean value from settings' saved configurations from SettingsManager
+
+        Args:
+            key (str): The CONFIG_KEY of the configuration
+
+        Returns:
+            bool: The config value
+        """
+
+        value = cls.GetFromSettingsConfigurations(key).lower()
+        return bool(value in BooleanAnswers.TRUE_ANSWERS)

--- a/IoTuring/Settings/SettingsManager.py
+++ b/IoTuring/Settings/SettingsManager.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from IoTuring.Settings.Settings import Settings
+    from IoTuring.Configurator.Configuration import SingleConfiguration
+
+from IoTuring.Logger.Logger import Singleton
+from IoTuring.Logger.LogObject import LogObject
+
+
+class SettingsManager(LogObject, metaclass=Singleton):
+    """Singleton for storing configurations of Settings"""
+
+    def __init__(self) -> None:
+        self.setting_configs = {}
+
+    def AddSettings(self, setting_entities: list[Settings]) -> None:
+        """Add settings configuration
+
+        Args:
+            setting_entities (list[Settings]): The loaded settings classes
+        """
+        for setting_entity in setting_entities:
+            self.setting_configs[setting_entity.NAME] = setting_entity.configurations
+
+    def GetConfigOfType(self, setting_class) -> SingleConfiguration:
+        """Get the configuration of a saved class. Raises exception if not found"""
+
+        if setting_class.NAME in self.setting_configs:
+            return self.setting_configs[setting_class.NAME]
+        else:
+            raise Exception(f"No settings config for {setting_class.NAME}")

--- a/IoTuring/Warehouse/Deployments/MQTTWarehouse/MQTTWarehouse.py
+++ b/IoTuring/Warehouse/Deployments/MQTTWarehouse/MQTTWarehouse.py
@@ -9,7 +9,6 @@ import os  # To get this folder path
 import time
 
 
-SLEEP_TIME_NOT_CONNECTED_WHILE = 1
 
 TOPIC_FORMAT = "{}/{}/{}"  # That stands for: App name, Client name, EntityData Id
 
@@ -53,7 +52,7 @@ class MQTTWarehouse(Warehouse):
 
     def Loop(self):
         while(not self.client.IsConnected()):
-            time.sleep(SLEEP_TIME_NOT_CONNECTED_WHILE)
+            time.sleep(self.retry_interval)
             
         # Here in Loop I send sensor's data (command callbacks are not managed here)
         for entity in self.GetEntities():

--- a/IoTuring/Warehouse/Warehouse.py
+++ b/IoTuring/Warehouse/Warehouse.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
-from IoTuring.Entity.Entity import Entity
-from IoTuring.Logger.LogObject import LogObject
-from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
-from IoTuring.Configurator.Configuration import SingleConfiguration
-from IoTuring.Entity.EntityManager import EntityManager
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from IoTuring.Entity.Entity import Entity
+    from IoTuring.Configurator.Configuration import SingleConfiguration
 
 from threading import Thread
 import time
 
-DEFAULT_LOOP_TIMEOUT = 10
+from IoTuring.Logger.LogObject import LogObject
+from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
+from IoTuring.Entity.EntityManager import EntityManager
+
+from IoTuring.Settings.Deployments.AppSettings.AppSettings import AppSettings, CONFIG_KEY_UPDATE_INTERVAL
 
 
 class Warehouse(ConfiguratorObject, LogObject):
@@ -16,7 +19,8 @@ class Warehouse(ConfiguratorObject, LogObject):
     def __init__(self, single_configuration: SingleConfiguration) -> None:
         super().__init__(single_configuration)
 
-        self.loopTimeout = DEFAULT_LOOP_TIMEOUT
+        self.loopTimeout = int(
+            AppSettings.GetFromSettingsConfigurations(CONFIG_KEY_UPDATE_INTERVAL))
 
     def Start(self) -> None:
         """ Initial configuration and start the thread that will loop the Warehouse.Loop() function"""

--- a/IoTuring/Warehouse/Warehouse.py
+++ b/IoTuring/Warehouse/Warehouse.py
@@ -11,7 +11,7 @@ from IoTuring.Logger.LogObject import LogObject
 from IoTuring.Configurator.ConfiguratorObject import ConfiguratorObject
 from IoTuring.Entity.EntityManager import EntityManager
 
-from IoTuring.Settings.Deployments.AppSettings.AppSettings import AppSettings, CONFIG_KEY_UPDATE_INTERVAL
+from IoTuring.Settings.Deployments.AppSettings.AppSettings import AppSettings, CONFIG_KEY_UPDATE_INTERVAL, CONFIG_KEY_RETRY_INTERVAL
 
 
 class Warehouse(ConfiguratorObject, LogObject):
@@ -21,6 +21,8 @@ class Warehouse(ConfiguratorObject, LogObject):
 
         self.loopTimeout = int(
             AppSettings.GetFromSettingsConfigurations(CONFIG_KEY_UPDATE_INTERVAL))
+        self.retry_interval = int(AppSettings
+                                  .GetFromSettingsConfigurations(CONFIG_KEY_RETRY_INTERVAL))
 
     def Start(self) -> None:
         """ Initial configuration and start the thread that will loop the Warehouse.Loop() function"""

--- a/IoTuring/__init__.py
+++ b/IoTuring/__init__.py
@@ -9,6 +9,7 @@ from IoTuring.MyApp.App import App
 from IoTuring.Configurator.Configurator import Configurator
 from IoTuring.Configurator.ConfiguratorLoader import ConfiguratorLoader
 from IoTuring.Entity.EntityManager import EntityManager
+from IoTuring.Settings.SettingsManager import SettingsManager
 from IoTuring.Logger.Logger import Logger
 from IoTuring.Logger.Colors import Colors
 
@@ -72,9 +73,17 @@ def loop():
     # This have to start after configurator.Menu(), otherwise won't work starting from the menu
     signal.signal(signal.SIGINT, Exit_SIGINT_handler)
 
+    # Load Settings:
+    settings = ConfiguratorLoader(configurator).LoadSettings()
+    sM = SettingsManager()
+    sM.AddSettings(settings)
+
     logger.Log(Logger.LOG_INFO, "App", App())  # Print App info
-    logger.Log(Logger.LOG_INFO, "Configurator",
-               "Run the script with -c to enter configuration mode")
+
+    # Add help if not started from Configurator
+    if not args.configurator:
+        logger.Log(Logger.LOG_INFO, "Configurator",
+                   "Run the script with -c to enter configuration mode")
 
     eM = EntityManager()
 


### PR DESCRIPTION
- Part 4 of #90 separation
- New class next to Warehouses and Entities: Settings
- Currently only one type of settings available: AppSettings, and there two option: 
  - Change the update interval
  - Change the retry interval after connection to broker is lost. Useful to increment for laptops, where losing connection is expected.
- SettingsManager is a Singleton, where Settings' configs stored.
- You can get the settings from the Settings Classes itself, it's not necessary to call SettingsManager directly, this is the basic pattern how config values can be returned:
```
from IoTuring.Settings.Deployments.AppSettings.AppSettings import AppSettings, CONFIG_KEY_UPDATE_INTERVAL

self.updateTimeout = int(AppSettings.GetFromSettingsConfigurations(CONFIG_KEY_UPDATE_INTERVAL))
```

Closes #5 