### PR TITLE
Restart Linux service on login

### DIFF
--- a/docs/Autostart tips.md
+++ b/docs/Autostart tips.md
@@ -45,9 +45,6 @@ sudo cp docs/IoTuring.service /usr/lib/systemd/user/
 mkdir -p ~/.local/share/systemd/user/
 cp docs/IoTuring.service ~/.local/share/systemd/user/
 
-# Enable the automatic login of the user, so it can start after boot
-loginctl enable-linger $(whoami)
-
 systemctl --user daemon-reload
 systemctl --user edit IoTuring.service
 ```
@@ -69,6 +66,22 @@ Enable and start the service:
 ```shell
 systemctl --user enable IoTuring.service
 systemctl --user start IoTuring.service
+```
+
+#### Start user service before login
+
+This is optional. Without this, IoTuring starts after login.
+
+```shell
+# Enable the automatic login of the user, so IoTuring can start right after boot:
+loginctl enable-linger $(whoami)
+
+# Copy the service which restarts IoTuring:
+cp docs/IoTuring-restart.service ~/.local/share/systemd/user/
+
+systemctl --user daemon-reload
+systemctl --user enable IoTuring-restart.service
+systemctl --user start IoTuring-restart.service
 ```
 
 ### As a system service with Systemd

--- a/docs/IoTuring-restart.service
+++ b/docs/IoTuring-restart.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Restart IoTuring after login
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl --user restart IoTuring.service
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Small Linux autostart doc fix: Restart IoTuring service on login. Without this, some entities were not initialized correctly.