### PR TITLE
only import mac dependencies if OsD.IsMacos()

### DIFF
--- a/IoTuring/Configurator/ConfiguratorIO.py
+++ b/IoTuring/Configurator/ConfiguratorIO.py
@@ -8,12 +8,13 @@ from IoTuring.MyApp.App import App  # App name
 from IoTuring.MyApp.SystemConsts import OperatingSystemDetection as OsD
 
 # macOS dep (in PyObjC)
-try:
-    from AppKit import *  # type:ignore
-    from Foundation import *  # type:ignore
-    macos_support = True
-except:
-    macos_support = False
+if OsD.IsMacos():
+    try:
+        from AppKit import *  # type:ignore
+        from Foundation import *  # type:ignore
+        macos_support = True
+    except:
+        macos_support = False
 
 CONFIG_PATH_ENV_VAR = "IOTURING_CONFIG_DIR"
 

--- a/IoTuring/Settings/Deployments/LogSettings/LogSettings.py
+++ b/IoTuring/Settings/Deployments/LogSettings/LogSettings.py
@@ -11,12 +11,13 @@ from IoTuring.Logger import consts
 
 
 # macOS dep (in PyObjC)
-try:
-    from AppKit import *  # type:ignore
-    from Foundation import *  # type:ignore
-    macos_support = True
-except:
-    macos_support = False
+if OsD.IsMacos():
+    try:
+        from AppKit import *  # type:ignore
+        from Foundation import *  # type:ignore
+        macos_support = True
+    except:
+        macos_support = False
 
 
 CONFIG_KEY_CONSOLE_LOG_LEVEL = "console_log_level"


### PR DESCRIPTION
Someone before me stumbled upon this MacOS dependecy import that always raises an exception on every other OS. The MyPy ignores don’t work in my dev env (vscode, debugpy which uses #@IgnoreException).

Sadly i did not find a way to configure debugpys ignore exception tags
https://github.com/microsoft/debugpy/blob/514e54fa2b87951e571ac5b6596c461f6644432a/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py#L51
If this change is breaking something else, i’d be happy to just add @IgnoreException