### PR TITLE
Run local tests with Dockerfile instead of shell script

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,7 +45,7 @@ The project uses [calendar versioning](https://calver.org/):
 ### Run tests in docker:
 
 ```shell
-docker run --rm -it -v .:/srv/IoTuring:ro python:3.8.17-slim-bullseye /srv/IoTuring/tests/run_tests.sh
+docker run --rm -it $(docker build -q -f tests.Dockerfile .)
 ```
 
 ### Run tests in a venv

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8.17-slim-bullseye
+
+WORKDIR /root/IoTuring
+
+COPY . .
+
+RUN pip install --no-cache-dir .[test]
+
+CMD python -m pytest
+
+# docker run --rm -it $(docker build -q -f tests.Dockerfile .)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# docker run --rm -it -v .:/srv/IoTuring:ro python:3.8.17-slim-bullseye /srv/IoTuring/tests/run_tests.sh
-
-apt update
-apt install git -y
-git clone /srv/IoTuring
-pip install "./IoTuring[test]"
-pytest IoTuring


### PR DESCRIPTION
Before Docker copied only committed changes. With Dockerfile it's possible to run tests with the live code, on any python version. 